### PR TITLE
fix problem with empty TypedQueryBean already enhanced

### DIFF
--- a/src/main/java/io/ebean/enhance/querybean/TypeQueryClassAdapter.java
+++ b/src/main/java/io/ebean/enhance/querybean/TypeQueryClassAdapter.java
@@ -145,6 +145,10 @@ public class TypeQueryClassAdapter extends ClassVisitor implements Constants {
 
   @Override
   public void visitEnd() {
+    if (classInfo.isAlreadyEnhanced()) {
+      throw new AlreadyEnhancedException(className);
+    }
+
     if (classInfo.isTypeQueryBean()) {
       if (!typeQueryRootBean) {
         classInfo.addAssocBeanExtras(cv);


### PR DESCRIPTION
When I have an empty TypedQueryBean (without fields), the agent will "re-enhance" the class, ending up with to annotations `@AlreadyEnhancedMarker`.

For example:

```java
@TypeQueryBean
public class QExternalAuthentication extends TQRootBean<ExternalAuthentication,QExternalAuthentication> {

  private static final QExternalAuthentication _alias = new QExternalAuthentication(true);
  public static QExternalAuthentication alias() {
    return _alias;
  }
  public QExternalAuthentication(EbeanServer server) {
    super(ExternalAuthentication.class, server);
  }
  public QExternalAuthentication() {
    super(ExternalAuthentication.class);
  }
  private QExternalAuthentication(boolean dummy) {
    super(dummy);
  }
  public static class Alias {
  }
}
```
When the agent executes two times without recompiling the class, the class becomes:

```java
@TypeQueryBean
@AlreadyEnhancedMarker
@AlreadyEnhancedMarker
public class QExternalAuthentication extends TQRootBean<ExternalAuthentication, QExternalAuthentication> {
    private static final QExternalAuthentication _alias = new QExternalAuthentication(true);

    public static QExternalAuthentication alias() {
        return _alias;
    }

    public QExternalAuthentication(EbeanServer server) {
        super(ExternalAuthentication.class, server);
        this.setRoot(this);
    }

    public QExternalAuthentication() {
        super(ExternalAuthentication.class);
        this.setRoot(this);
    }

    private QExternalAuthentication(boolean alias) {
        super(alias);
        this.setRoot(this);
    }

    public static class Alias {
        public Alias() {
        }
    }
}

```

The fix I implemented is just checking if the class has the marker at the end of the visitor.