### PR TITLE
FIX: Ebean.toJson when not enhanced MappedSuper is used

### DIFF
--- a/src/main/java/io/ebean/enhance/common/ClassMeta.java
+++ b/src/main/java/io/ebean/enhance/common/ClassMeta.java
@@ -269,7 +269,7 @@ public class ClassMeta {
   public boolean hasPersistentFields() {
     
     for (FieldMeta fieldMeta : fields.values()) {
-      if (fieldMeta.isPersistent()) {
+      if (fieldMeta.isPersistent() || fieldMeta.isTransient()) {
         return true;
       }
     }

--- a/src/test/java/test/model/NoEnhanceMappedSuper.java
+++ b/src/test/java/test/model/NoEnhanceMappedSuper.java
@@ -8,7 +8,6 @@ public class NoEnhanceMappedSuper {
 
   static String oneStatic;
   
-  @Transient
-  String oneInstance;
+  transient String oneInstance;
   
 }


### PR DESCRIPTION
Hello Rob,

I discovered a bug that I cannot convert a bean to JSON when a @MappedSuperClass is used that is not enhanced, because it contains only @Transient properties.

**How to reproduce**
https://github.com/FOCONIS/ebean/commit/3cea9987024fdc8c7a6e020d59183c63fc778bed

**Analysis**
json.toJson() tries also to serialize @ Transient properties (but not "private transient" ones) and the ebean-agent enhances a class only, if there is at least one non-transient property.
In the runtime, there is a BeanProperty for this transient property, but no getter/setter in this property and it will NPE here in 
```
public Object getValueIntercept(EntityBean bean) {
    try {
      return getter.getIntercept(bean);
...
  }
```

**Possible Workaround**
Mark all @Transient properties in a MappedSuper-class also with @ JsonIgnore 


**Expected behavior # 1 (my preferred option)**
json.toJson() should not serialize @ Transient properties. I cannot use the "transient" modifier, as I will serialize these information in my HTTP-Session

A fix that solves **my** problem is seen here:
https://github.com/FOCONIS/ebean/commit/af51dec58422e4668942bcac96661cabb32f1ecb
but this probably means a big change for every one else that uses the serializion feature (so I think this is not acceptable for others.

**Expected behavior # 2**
agent should enhance @MappedSuperClasses to be consistent and serialize also all @Transient properties of the MappedSuperClass 


**Stack Trace**

```
java.lang.RuntimeException: getIntercept oneInstance on [org.tests.enhancement.EntityTestB] type[org.tests.enhancement.EntityTestB] threw error.
	at io.ebeaninternal.server.deploy.BeanProperty.getValueIntercept(BeanProperty.java:815)
	at io.ebeaninternal.server.deploy.BeanProperty.jsonWrite(BeanProperty.java:1358)
	at io.ebeaninternal.server.text.json.WriteJson$WriteBean.write(WriteJson.java:505)
	at io.ebeaninternal.server.deploy.BeanDescriptorJsonHelp.jsonWriteProperties(BeanDescriptorJsonHelp.java:49)
	at io.ebeaninternal.server.deploy.BeanDescriptorJsonHelp.jsonWrite(BeanDescriptorJsonHelp.java:32)
	at io.ebeaninternal.server.deploy.BeanDescriptor.jsonWrite(BeanDescriptor.java:3037)
	at io.ebeaninternal.server.text.json.DJsonContext.toJsonInternal(DJsonContext.java:338)
	at io.ebeaninternal.server.text.json.DJsonContext.toJsonString(DJsonContext.java:308)
	at io.ebeaninternal.server.text.json.DJsonContext.toJson(DJsonContext.java:297)
	at org.tests.enhancement.TestToJson.testEntityB(TestToJson.java:31)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:86)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:678)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)
Caused by: java.lang.NullPointerException
	at io.ebeaninternal.server.deploy.BeanProperty.getValueIntercept(BeanProperty.java:811)
	... 32 more

```