### PR TITLE
Use bean getter setter

### DIFF
--- a/src/main/java/io/ebean/enhance/common/ClassMeta.java
+++ b/src/main/java/io/ebean/enhance/common/ClassMeta.java
@@ -383,7 +383,8 @@ public class ClassMeta {
 	public void addExistingMethod(String methodName, String methodDesc) {
 		existingMethods.add(methodName + methodDesc);
 		if (isSetter(methodName, methodDesc)) {
-			beanSetters.put(methodName, methodDesc);
+			String fieldDesc = methodDesc.substring(0,methodDesc.indexOf(')')+1);
+			beanSetters.put(methodName + fieldDesc, methodDesc);
 		}
 	}
 	
@@ -394,14 +395,29 @@ public class ClassMeta {
 				&& HAS_SINGLE_ARGUMENT.matcher(methodDesc).matches();
 	}
 
-	public String getSetterDesc(String methodName) {
-		return beanSetters.get(methodName);
+	public String getSetterDesc(String methodName, String fieldDesc) {
+		return getSetterDesc(methodName + "(" + fieldDesc + ")");
+	}
+	public String getSetterDesc(String methodNameAndParamDesc) {
+		String ret = beanSetters.get(methodNameAndParamDesc);
+		if (ret == null && superMeta != null) {
+			return superMeta.getSetterDesc(methodNameAndParamDesc);
+		}
+		return ret;
 	}
 	/**
 	 * Return true if the method already exists on the bean.
 	 */
 	public boolean isExistingMethod(String methodName, String methodDesc) {
-		return existingMethods.contains(methodName + methodDesc);
+		return isExistingMethod(methodName + methodDesc);
+	}
+	
+	/**
+	 * Return true if the method already exists on the bean.
+	 */
+	public boolean isExistingMethod(String methodNameAndDesc) {
+		return existingMethods.contains(methodNameAndDesc) 
+				|| (superMeta != null && superMeta.isExistingMethod(methodNameAndDesc));
 	}
 
 	public MethodVisitor createMethodVisitor(MethodVisitor mv, int access, String name, String desc) {

--- a/src/main/java/io/ebean/enhance/common/ClassMetaReaderVisitor.java
+++ b/src/main/java/io/ebean/enhance/common/ClassMetaReaderVisitor.java
@@ -101,7 +101,9 @@ public class ClassMetaReaderVisitor extends ClassVisitor implements EnhanceConst
     if (name.equals("equals") && desc.equals("(Ljava/lang/Object;)Z")) {
       classMeta.setHasEqualsOrHashcode(true);
     }
-		
+    if (!staticAccess) {
+		classMeta.addExistingMethod(name, desc);
+    }
 		MethodVisitor mv = super.visitMethod(access, name, desc, signature, exceptions);
 		if (!staticAccess && readMethodMeta){
 			return classMeta.createMethodVisitor(mv, access, name, desc);

--- a/src/main/java/io/ebean/enhance/entity/FieldMeta.java
+++ b/src/main/java/io/ebean/enhance/entity/FieldMeta.java
@@ -318,7 +318,7 @@ public class FieldMeta implements Opcodes, EnhanceConstants {
 
     if (intercept) {
       // try to find the bean setter (the setter may not return void, if fluent pattern is used)
-      String methodDesc = classMeta.getSetterDesc(beanSetterName);
+      String methodDesc = classMeta.getSetterDesc(beanSetterName, fieldDesc);
       String methodName = beanSetterName;
       if (methodDesc == null) {
         // no setter found, go through the set method to check for interception...
@@ -326,6 +326,11 @@ public class FieldMeta implements Opcodes, EnhanceConstants {
         methodDesc = setMethodDesc;
       }
       mv.visitMethodInsn(INVOKEVIRTUAL, classMeta.getClassName(), methodName, methodDesc, false);
+      if (methodDesc.endsWith("D") || methodDesc.endsWith("J")) {
+    	  mv.visitInsn(POP2); // discard double or long
+      }else if (!methodDesc.endsWith("V")) {
+    	  mv.visitInsn(POP); // discard everything else, but not void.
+      }
 
     } else {
       mv.visitMethodInsn(INVOKEVIRTUAL, classMeta.getClassName(), setNoInterceptMethodName, setMethodDesc, false);

--- a/src/test/java/io/ebean/enhance/common/IsSetterPatternTest.java
+++ b/src/test/java/io/ebean/enhance/common/IsSetterPatternTest.java
@@ -1,0 +1,29 @@
+package io.ebean.enhance.common;
+
+import org.testng.annotations.Test;
+
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class IsSetterPatternTest {
+
+	private static final Pattern PATTERN = ClassMeta.HAS_SINGLE_ARGUMENT;
+	@Test
+	public void testPattern() throws Exception {
+		assertThat("(Ljava/lang/Long;)V").matches(PATTERN);
+		assertThat("(Ljava/lang/String;)Ltest/model/WithGetterSetter;").matches(PATTERN);
+		assertThat("(Ljava/lang/Integer;)Ltest/model/WithGetterSetter;").matches(PATTERN);
+		assertThat("(Z)Ltest/model/WithGetterSetter;").matches(PATTERN);
+		assertThat("(J)V").matches(PATTERN);
+		assertThat("()Ltest/model/WithGetterSetter;").doesNotMatch(PATTERN);
+		assertThat("(II)V").doesNotMatch(PATTERN);
+		assertThat("(I[I)V").doesNotMatch(PATTERN);
+		assertThat("(Ljava/lang/Object;[I)V").doesNotMatch(PATTERN);
+		assertThat("([Ljava/lang/Object;)V").matches(PATTERN);
+		assertThat("(Ljava/lang/Object;[I)V").doesNotMatch(PATTERN);
+		assertThat("([I)V").matches(PATTERN);
+
+	}
+
+}

--- a/src/test/java/test/enhancement/WithGetterSetterTests.java
+++ b/src/test/java/test/enhancement/WithGetterSetterTests.java
@@ -1,0 +1,46 @@
+package test.enhancement;
+
+import io.ebean.Ebean;
+import io.ebean.plugin.BeanType;
+import io.ebean.plugin.ExpressionPath;
+import org.testng.annotations.Test;
+import test.model.WithGetterSetter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class WithGetterSetterTests extends BaseTest {
+
+
+  @Test
+  public void testGetterSetterRoundtrip() {
+	  WithGetterSetter bean = new WithGetterSetter();
+	  assertThat(bean.log).isEmpty();
+	  
+	  bean.setName("foo");
+	  assertThat(bean.log).containsExactly("setName");
+	  
+	  Ebean.save(bean);
+	  
+	  bean = Ebean.find(WithGetterSetter.class, bean.getId());
+	  assertThat(bean.log).isEmpty();
+	  assertThat(bean.getName()).isEqualTo("foo");
+	  assertThat(bean.log).containsExactly("getName");
+
+  }
+  @Test
+  public void testGetterSetterElPath() {
+	  WithGetterSetter bean = new WithGetterSetter();
+	  assertThat(bean.log).isEmpty();
+
+	  BeanType<WithGetterSetter> beanType = Ebean.getDefaultServer().getPluginApi().getBeanType(WithGetterSetter.class);
+	  ExpressionPath path = beanType.getExpressionPath("name");
+	  path.pathGet(bean);
+	  assertThat(bean.log).containsExactly("getName");
+	  
+	  bean.log.clear();
+	  
+	  path.pathSet(bean, "foo");
+	  assertThat(bean.log).containsExactly("setName");
+
+  }
+}

--- a/src/test/java/test/model/WithGetterSetter.java
+++ b/src/test/java/test/model/WithGetterSetter.java
@@ -1,0 +1,79 @@
+package test.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.persistence.Entity;
+
+@Entity
+public class WithGetterSetter extends BaseEntity {
+
+	public transient List<String> log = new ArrayList<String>();
+	
+	String name;
+
+	Integer count;
+
+	boolean flag;
+
+	long number;
+
+	@Override
+	public void setId(Long id) {
+		log.add("setId");
+		super.setId(id);
+	}
+	
+	public String getName() {
+		log.add("getName");
+		return name;
+	}
+
+	public WithGetterSetter setName(String name) {
+		log.add("setName");
+		this.name = name;
+		return this;
+	}
+
+	public Integer getCount() {
+		log.add("getCount");
+		return count;
+	}
+
+	public WithGetterSetter setCount(Integer count) {
+		log.add("setCount");
+		this.count = count;
+		return this;
+	}
+
+	public boolean isFlag() {
+		log.add("isFlag");
+		return flag;
+	}
+
+	public WithGetterSetter setFlag(boolean flag) {
+		log.add("setFlag");
+		this.flag = flag;
+		return this;
+	}
+
+	public long getNumber() {
+		log.add("getNumber");
+		return number;
+	}
+
+	public void setNumber(long number) {
+		log.add("setNumber");
+		this.number = number;
+	}
+	
+	// some different setters to test the setter detection in fieldMeta
+	
+	public WithGetterSetter setNumber() { return this; }
+	public void setNumber(int i, int j) { }
+	public void setNumber(int i, int[] j) { }
+	public void setNumber(Object o, int[] j) { }
+	public void setArray1(Object[] o) { }
+	public void setArray2(int[] i) { }
+	
+}

--- a/src/test/java/test/model/WithGetterSetter.java
+++ b/src/test/java/test/model/WithGetterSetter.java
@@ -17,6 +17,10 @@ public class WithGetterSetter extends BaseEntity {
 	boolean flag;
 
 	long number;
+	
+	double salary;
+	
+	int age;
 
 	@Override
 	public void setId(Long id) {
@@ -62,13 +66,34 @@ public class WithGetterSetter extends BaseEntity {
 		return number;
 	}
 
-	public void setNumber(long number) {
+	public long setNumber(long number) {
 		log.add("setNumber");
+		long oldValue = this.number;
 		this.number = number;
+		return oldValue;
 	}
 	
-	// some different setters to test the setter detection in fieldMeta
+	public double setSalary(double salary) {
+		double oldValue = this.salary;
+		this.salary = salary;
+		return oldValue;
+	}
 	
+	public int setAge(int age) {
+		int oldValue = this.age;
+		this.age = age;
+		return oldValue;
+	}
+	
+
+	// some different setters to test the setter detection in fieldMeta
+	public void setAge(double age) {
+		this.age = (int) age;
+	}
+	
+	public void setSalary(int salary) {
+		this.salary = (double) salary;
+	}
 	public WithGetterSetter setNumber() { return this; }
 	public void setNumber(int i, int j) { }
 	public void setNumber(int i, int[] j) { }


### PR DESCRIPTION
Hello Rob, this PR could be a replacement for the PropertyChangeSupport:

we have used the PropertyChange support to modify other fields (in the same model):
e.g. when you change the country of an address, we cleared city and street.

Unfortunately, ebean bypasses the bean setters till now when you use EL to modify the bean.
So I had to use PCS.

With this PR I can overwrite the setters and implement the functionality there
```
void setCountry(String country) {
  String oldValue = this.country;
  this.country = country;
  if (!Objects.equals(oldValue, country)) {
    setStreet("");
  }
}
```


