### PR TITLE
renamed tests

### DIFF
--- a/src/test/java/test/enhancement/BaseWithEqualsTest.java
+++ b/src/test/java/test/enhancement/BaseWithEqualsTest.java
@@ -7,7 +7,7 @@ import test.model.BExtends;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-public class BaseWithEqualsTests {
+public class BaseWithEqualsTest {
 
   @Test
   public void test() {

--- a/src/test/java/test/enhancement/ClassMetaReaderTest.java
+++ b/src/test/java/test/enhancement/ClassMetaReaderTest.java
@@ -15,7 +15,7 @@ import io.ebean.enhance.common.EnhanceContext;
 
 import static org.testng.Assert.*;
 
-public class ClassMetaReaderTests {
+public class ClassMetaReaderTest {
 
   @Test
   public void checkOtherClass_withAnnotations() throws ClassNotFoundException {

--- a/src/test/java/test/enhancement/CreateNullListTest.java
+++ b/src/test/java/test/enhancement/CreateNullListTest.java
@@ -13,7 +13,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-public class CreateNullListTests extends BaseTest {
+public class CreateNullListTest extends BaseTest {
 
   @Test
   public void test() {

--- a/src/test/java/test/enhancement/CustomerEntityTest.java
+++ b/src/test/java/test/enhancement/CustomerEntityTest.java
@@ -13,7 +13,7 @@ import java.util.Date;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
-public class CustomerEntityTests extends BaseTest {
+public class CustomerEntityTest extends BaseTest {
 
   private static final int PROPERTY_COUNT = 6;
 

--- a/src/test/java/test/enhancement/LazyLoadingInvokeTest.java
+++ b/src/test/java/test/enhancement/LazyLoadingInvokeTest.java
@@ -10,7 +10,7 @@ import test.model.Customer;
 
 import java.util.List;
 
-public class LazyLoadingInvokeTests extends BaseTest {
+public class LazyLoadingInvokeTest extends BaseTest {
 
   @Test
   public void testNoLazyLoadOnToString() {

--- a/src/test/java/test/enhancement/MappedSuperWithEqualsTest.java
+++ b/src/test/java/test/enhancement/MappedSuperWithEqualsTest.java
@@ -5,7 +5,7 @@ import test.model.AMappedSuperChild;
 
 import static org.testng.Assert.assertEquals;
 
-public class MappedSuperWithEqualsTests extends BaseTest {
+public class MappedSuperWithEqualsTest extends BaseTest {
 
   @Test
   public void test() {

--- a/src/test/java/test/enhancement/PBeanTest.java
+++ b/src/test/java/test/enhancement/PBeanTest.java
@@ -8,7 +8,7 @@ import static org.testng.Assert.*;
 
 /**
  */
-public class PBeanTests extends BaseTest {
+public class PBeanTest extends BaseTest {
 
   @Test
   public void testBasic() {

--- a/src/test/java/test/enhancement/PersistentFileTest.java
+++ b/src/test/java/test/enhancement/PersistentFileTest.java
@@ -7,7 +7,7 @@ import static org.testng.Assert.assertNotNull;
 
 /**
  */
-public class PersistentFileTests extends BaseTest {
+public class PersistentFileTest extends BaseTest {
 
 
   @Test

--- a/src/test/java/test/enhancement/SomeAbstractClassTest.java
+++ b/src/test/java/test/enhancement/SomeAbstractClassTest.java
@@ -2,27 +2,32 @@ package test.enhancement;
 
 import io.ebean.bean.EntityBean;
 import org.testng.annotations.Test;
-import test.model.SomeBeanWithInterface;
+import test.model.SomeAbstractClass;
+import test.model.SomeExtendsAbstract;
+import test.model.SomeInterface;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
-/**
- */
-public class SomeInterfaceTests extends BaseTest {
+public class SomeAbstractClassTest extends BaseTest {
 
 
   @Test
   public void testBasic() {
 
     // make sure we can construct it
-    SomeBeanWithInterface bean = new SomeBeanWithInterface();
+    SomeExtendsAbstract bean = new SomeExtendsAbstract();
     assertNotNull(bean);
+
+    assertTrue(bean instanceof EntityBean);
+    assertTrue(bean instanceof SomeInterface);
+    assertTrue(bean instanceof SomeAbstractClass);
 
     EntityBean eb = (EntityBean)bean;
     String[] props = eb._ebean_getPropertyNames();
     assertEquals(2, props.length);
     assertEquals("id", props[0]);
-    assertEquals("code", props[1]);
+    assertEquals("name", props[1]);
   }
 }

--- a/src/test/java/test/enhancement/SomeInterfaceTest.java
+++ b/src/test/java/test/enhancement/SomeInterfaceTest.java
@@ -2,32 +2,27 @@ package test.enhancement;
 
 import io.ebean.bean.EntityBean;
 import org.testng.annotations.Test;
-import test.model.SomeAbstractClass;
-import test.model.SomeExtendsAbstract;
-import test.model.SomeInterface;
+import test.model.SomeBeanWithInterface;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
 
-public class SomeAbstractClassTests extends BaseTest {
+/**
+ */
+public class SomeInterfaceTest extends BaseTest {
 
 
   @Test
   public void testBasic() {
 
     // make sure we can construct it
-    SomeExtendsAbstract bean = new SomeExtendsAbstract();
+    SomeBeanWithInterface bean = new SomeBeanWithInterface();
     assertNotNull(bean);
-
-    assertTrue(bean instanceof EntityBean);
-    assertTrue(bean instanceof SomeInterface);
-    assertTrue(bean instanceof SomeAbstractClass);
 
     EntityBean eb = (EntityBean)bean;
     String[] props = eb._ebean_getPropertyNames();
     assertEquals(2, props.length);
     assertEquals("id", props[0]);
-    assertEquals("name", props[1]);
+    assertEquals("code", props[1]);
   }
 }

--- a/src/test/java/test/enhancement/SomeXtendsBaseWithEqualsTest.java
+++ b/src/test/java/test/enhancement/SomeXtendsBaseWithEqualsTest.java
@@ -7,7 +7,7 @@ import static org.testng.Assert.assertEquals;
 
 /**
  */
-public class SomeXtendsBaseWithEqualsTests extends BaseTest {
+public class SomeXtendsBaseWithEqualsTest extends BaseTest {
 
 
   @Test

--- a/src/test/java/test/enhancement/WithInitialisedCollectionsTest.java
+++ b/src/test/java/test/enhancement/WithInitialisedCollectionsTest.java
@@ -16,7 +16,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
-public class WithInitialisedCollectionsTests extends BaseTest {
+public class WithInitialisedCollectionsTest extends BaseTest {
 
 
   @Test


### PR DESCRIPTION
Maven surefire does not find tests if class ends with "...Tests" instead of "...Test" - so I renamed the tests that they are executed in a maven build.

Unfortunately, two tests are failing now:
  checkTransactionalAtClassLevel(test.enhancement.ClassMetaReaderTest): expected [false] but found [null]
  testEnhanceContext(test.enhancement.ClassMetaReaderTest): expected [true] but found [false]