### PR TITLE
@Transactional on class levels causes <clinit> to get enhanced

### DIFF
--- a/src/test/java/test/model/SomeTransactionalWithStatic.java
+++ b/src/test/java/test/model/SomeTransactionalWithStatic.java
@@ -8,7 +8,7 @@ import io.ebean.annotation.TxType;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
-@Transactional(type = TxType.SUPPORTS)
+@Transactional(type = TxType.REQUIRED)
 public class SomeTransactionalWithStatic {
 
   static {

--- a/src/test/java/test/model/SomeTransactionalWithStatic.java
+++ b/src/test/java/test/model/SomeTransactionalWithStatic.java
@@ -3,13 +3,20 @@ package test.model;
 import io.ebean.Ebean;
 import io.ebean.Transaction;
 import io.ebean.annotation.Transactional;
+import io.ebean.annotation.TxType;
 
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
+@Transactional(type = TxType.SUPPORTS)
 public class SomeTransactionalWithStatic {
 
   static {
     Boolean anything = true;
+
+    Transaction tdTransaction = Ebean.currentTransaction();
+    System.out.println("--- in someMethod " + tdTransaction);
+    assertNull(tdTransaction);
   }
 
   @Transactional(label = "something")

--- a/src/test/java/test/model/SomeTransactionalWithStatic.java
+++ b/src/test/java/test/model/SomeTransactionalWithStatic.java
@@ -15,7 +15,7 @@ public class SomeTransactionalWithStatic {
     Boolean anything = true;
 
     Transaction tdTransaction = Ebean.currentTransaction();
-    System.out.println("--- in someMethod " + tdTransaction);
+    System.out.println("--- in <clinit> " + tdTransaction);
     assertNull(tdTransaction);
   }
 


### PR DESCRIPTION
When there is a Transactional annotation on class level the static class initializer gets enhanced. I changed the SomeTransactionWithStatic test to demonstrate this.

```
[TestNG] Running:
  /home/rnentjes/.IntelliJIdea2018.1/system/temp-testng-customsuite.xml
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
SLF4J: Failed to load class "org.slf4j.impl.StaticMDCBinder".
SLF4J: Defaulting to no-operation MDCAdapter implementation.
SLF4J: See http://www.slf4j.org/codes.html#no_static_mdc_binder for further details.
--- in <clinit> ScopedTransaction[ScopeTrans[txn[1003] ]]

java.lang.AssertionError: expected [null] but found [ScopedTransaction[ScopeTrans[txn[1003] ]]]
Expected :null
Actual   :ScopedTransaction[ScopeTrans[txn[1003] ]]
 <Click to see difference>


	at org.testng.Assert.fail(Assert.java:94)
	at org.testng.Assert.failNotSame(Assert.java:509)
	at org.testng.Assert.assertNull(Assert.java:445)
	at org.testng.Assert.assertNull(Assert.java:434)
	at test.model.SomeTransactionalWithStatic.<clinit>(SomeTransactionalWithStatic.java:19)
	at test.enhancement.SomeTransactionalWithStaticTest.testSomeMethod(SomeTransactionalWithStaticTest.java:11)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:86)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:643)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:820)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1128)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
	at org.testng.TestRunner.privateRun(TestRunner.java:782)
	at org.testng.TestRunner.run(TestRunner.java:632)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:366)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:361)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:319)
	at org.testng.SuiteRunner.run(SuiteRunner.java:268)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1244)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1169)
	at org.testng.TestNG.run(TestNG.java:1064)
	at org.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:72)
	at org.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:123)
```