### PR TITLE
notify listener only if logLevel is set (required for eclipse compiler)

### DIFF
--- a/src/main/java/io/ebean/enhance/ant/OfflineFileTransform.java
+++ b/src/main/java/io/ebean/enhance/ant/OfflineFileTransform.java
@@ -24,6 +24,8 @@ public class OfflineFileTransform {
 
   protected  TransformationListener listener;
 
+  private int logLevel;
+
   /**
   * Enhance the class file and replace the file with the the enhanced
   * version of the class.
@@ -37,6 +39,7 @@ public class OfflineFileTransform {
   */
   public OfflineFileTransform(Transformer transformer, ClassLoader classLoader, String inDir) {
     this.inputStreamTransform = new InputStreamTransform(transformer, classLoader);
+    logLevel = transformer.getLogLevel();
     inDir = trimSlash(inDir);
     this.inDir = inDir;
   }
@@ -150,7 +153,7 @@ public class OfflineFileTransform {
 
     if (result != null) {
       InputStreamTransform.writeBytes(result, file);
-      if(listener!=null) {
+      if(listener!=null && logLevel > 0) {
         listener.logEvent("Enhanced "+file);
       }
     }


### PR DESCRIPTION
(This is more or less a question, see below)

We use a modified version of the maven-eclipse-compiler plugin that does Lombok, AnnotationProcessing (querybeans) and enhancemnt in one step, as this speeds up the build a little bit. (plugin not yet public - if there is demand, contact me)

Here we use our own transformListner in the plugin
```
		OfflineFileTransform ft = new OfflineFileTransform(transformer, loader, classSource);
		ft.setListener(new TransformationListener() {

			@Override
			public void logEvent(final String msg) {
				getLogger().info(msg); // delegate to maven logger
			}

			@Override
			public void logError(final String msg) {
				getLogger().error(msg);
			}
		});
```
and the transformer floods the log.

@rbygrave While writing the PR comment, I checked, where `logEvent` is called and I see, there is only ONE place. `logError` is never called, So question is, why? (I believe, this was different in ebean < 11)

- Should we log more events? And where are the errors, should we log more?
- If not, is it worth to keep the TransformationListener, that is used only in one place or should we make it deprecated?

What do you think?  (I can remove my setListener also, if you decline this PR)


