### PR TITLE
FIX: empty arrays can override previous annotation

### DIFF
--- a/src/main/java/io/ebean/enhance/common/AnnotationInfo.java
+++ b/src/main/java/io/ebean/enhance/common/AnnotationInfo.java
@@ -2,6 +2,7 @@ package io.ebean.enhance.common;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Collects the annotation information.
@@ -41,17 +42,13 @@ public class AnnotationInfo {
   public void add(String prefix, String name, Object value){
     if (name == null){
       // this is an array value...
-      ArrayList<Object> list = (ArrayList<Object>)valueMap.get(prefix);
-      if (list == null){
-        list = new ArrayList<>();
-        valueMap.put(prefix, list);
+      List<Object> list = (List<Object>) valueMap.computeIfAbsent(prefix, k -> new ArrayList<>());
+      if (value != null) {
+        // add it if it is not null (null is not allowed in annotations, but used to init empty array)
+        list.add(value);
       }
-      //System.out.println("addArrayValue "+prefix+" value:"+value);
-      list.add(value);
-
     } else {
       String key = getKey(prefix, name);
-      //System.out.println("addValue "+key+" value:"+value);
       valueMap.put(key, value);
     }
   }

--- a/src/main/java/io/ebean/enhance/common/AnnotationInfoVisitor.java
+++ b/src/main/java/io/ebean/enhance/common/AnnotationInfoVisitor.java
@@ -16,6 +16,9 @@ public class AnnotationInfoVisitor extends AnnotationVisitor {
     super(Opcodes.ASM7, av);
     this.info = info;
     this.prefix = prefix;
+    if (prefix != null) {
+      info.add(prefix, null, null);
+    }
   }
 
   @Override


### PR DESCRIPTION
If you have an annotation with an arry type, you cannot override a class-level annotation at field level.

Example:

```java
public @interface MyAnnotation {
  Class<?>[] value();
}

@MyAnnotation({ Some.class, Object.class})
public class TestClass() {

   @MyAnnotation(Other.class)
   String test1; // actual: [Other.class] expected: [Other.class]

   // no anntoation, fall back to class level
   String test2; // actual: [Some.class, Object.class] expected: [Some.class, Object.class]

   @MyAnnotation({})
   String test3; // actual: [Some.class, Object.class] expected: []
}
```

(I discovered this issue, while developing this feature:
https://github.com/FOCONIS/ebean-agent/commit/63e1e45c4f05518a2897075cecb9130f8a17eaa2)