### PR TITLE
Fix file descriptor leak from URL connections to local files

### DIFF
--- a/src/main/java/io/ebean/enhance/common/AgentManifest.java
+++ b/src/main/java/io/ebean/enhance/common/AgentManifest.java
@@ -3,6 +3,7 @@ package io.ebean.enhance.common;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Set;
@@ -160,7 +161,9 @@ public class AgentManifest {
     while (resources.hasMoreElements()) {
       URL url = resources.nextElement();
       try {
-        addResource(url.openStream());
+        URLConnection con = url.openConnection();
+        con.setUseCaches(false);
+        addResource(con.getInputStream());
       } catch (IOException e) {
         System.err.println("Error reading manifest resources " + url);
         e.printStackTrace();

--- a/src/main/java/io/ebean/enhance/entity/ClassPathClassBytesReader.java
+++ b/src/main/java/io/ebean/enhance/entity/ClassPathClassBytesReader.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.net.URLConnection;
 
 /**
  * Implementation of ClassBytesReader based on URLClassLoader.
@@ -36,7 +37,9 @@ public class ClassPathClassBytesReader implements ClassBytesReader {
           return null;
         }
 
-        is = url.openStream();
+        URLConnection con = url.openConnection();
+        con.setUseCaches(false);
+        is = con.getInputStream();
         return InputStreamTransform.readBytes(is);
 
       } catch (IOException e){


### PR DESCRIPTION
The JVM keeps a cache of URL connections, which keeps the underlying files open for the lifetime of the VM. This is a problem when using it in long running build tools, like the Ebean Enhancer plugin for Gradle when run in as a daemon (which is the default).

This change disables caching of URL connections, which allows the agent to be used in the Gradle daemon process without preventing files from being deleted on Windows.

Note that there is a class called LocalClassLoader that looks like it has the same problem. I did not change that class as it is not actually used anywhere in the code or in the Gradle plugin, so I wouldn't be able to test the change. It is obviously not a problem for us for the same reason, but if it is used in some other plugins or projects that I am not aware of, you may want to change the URL connection in here too.

Fixes ebean-orm/ebean-agent#93