### PR TITLE
Fix resource leak on InputStreamTransform

### DIFF
--- a/src/main/java/io/ebean/enhance/common/InputStreamTransform.java
+++ b/src/main/java/io/ebean/enhance/common/InputStreamTransform.java
@@ -67,7 +67,9 @@ public class InputStreamTransform {
   * Helper method to write bytes to a file.
   */
   public static void writeBytes(byte[] bytes, File file) throws IOException {
-    writeBytes(bytes, new FileOutputStream(file));
+    try (final FileOutputStream fos = new FileOutputStream(file)) {
+      writeBytes(bytes, fos);
+    }
   }
 
   /**


### PR DESCRIPTION
Fix output resource leak on the method `writeBytes(byte[] bytes, File file)` located on the class InputStreamTransform.
