### PR TITLE
Fix possible array index out of bounds

### DIFF
--- a/src/main/java/io/ebean/enhance/asm/Frame.java
+++ b/src/main/java/io/ebean/enhance/asm/Frame.java
@@ -650,7 +650,7 @@ class Frame {
         if (kind == LOCAL_KIND) {
           initializedType = dim + inputLocals[value];
         } else if (kind == STACK_KIND) {
-          if (inputStack.length - value >= 0) {
+          if (inputStack.length - value >= 0 && value > 0) {
             initializedType = dim + inputStack[inputStack.length - value];
           } else {
             throw new RuntimeException("Can't find initialized type " + abstractType + " (IndexOutOfBoundsException)");


### PR DESCRIPTION
If value is set to zero, inputStack[inputStack.length - value] will produce
an IndexOutOfBoundException because of inputStack.length
