### PR TITLE
Add ACC_SYNTHETIC to generated Bytecode

### DIFF
--- a/src/main/java/io/ebean/enhance/entity/FieldMeta.java
+++ b/src/main/java/io/ebean/enhance/entity/FieldMeta.java
@@ -363,7 +363,7 @@ public class FieldMeta implements Opcodes, EnhanceConstants {
       classMeta.log(getMethodName + " " + getMethodDesc + " intercept:" + isInterceptGet() + " " + annotations);
     }
 
-    MethodVisitor mv = cw.visitMethod(ACC_PROTECTED, getMethodName, getMethodDesc, null, null);
+    MethodVisitor mv = cw.visitMethod(ACC_PROTECTED + ACC_SYNTHETIC, getMethodName, getMethodDesc, null, null);
     mv.visitCode();
 
     if (isInterceptMany()) {
@@ -500,7 +500,7 @@ public class FieldMeta implements Opcodes, EnhanceConstants {
       classMeta.log(getNoInterceptMethodName + " " + getMethodDesc);
     }
 
-    MethodVisitor mv = cw.visitMethod(ACC_PROTECTED, getNoInterceptMethodName, getMethodDesc, null, null);
+    MethodVisitor mv = cw.visitMethod(ACC_PROTECTED + ACC_SYNTHETIC, getNoInterceptMethodName, getMethodDesc, null, null);
     mv.visitCode();
 
     Label l0 = new Label();
@@ -545,7 +545,7 @@ public class FieldMeta implements Opcodes, EnhanceConstants {
           + " opCode:" + iLoadOpcode + "," + iPosition + " preSetterArgTypes" + preSetterArgTypes);
     }
 
-    MethodVisitor mv = cw.visitMethod(ACC_PROTECTED, setMethodName, setMethodDesc, null, null);
+    MethodVisitor mv = cw.visitMethod(ACC_PROTECTED + ACC_SYNTHETIC, setMethodName, setMethodDesc, null, null);
     mv.visitCode();
 
     Label l0 = new Label();
@@ -610,7 +610,7 @@ public class FieldMeta implements Opcodes, EnhanceConstants {
       classMeta.log(setNoInterceptMethodName + " " + setMethodDesc + " opCode:" + iLoadOpcode + "," + iPosition);
     }
 
-    MethodVisitor mv = cw.visitMethod(ACC_PROTECTED, setNoInterceptMethodName, setMethodDesc, null, null);
+    MethodVisitor mv = cw.visitMethod(ACC_PROTECTED + ACC_SYNTHETIC, setNoInterceptMethodName, setMethodDesc, null, null);
     mv.visitCode();
     Label l0 = new Label();
 

--- a/src/main/java/io/ebean/enhance/entity/IndexFieldWeaver.java
+++ b/src/main/java/io/ebean/enhance/entity/IndexFieldWeaver.java
@@ -73,7 +73,7 @@ public class IndexFieldWeaver implements Opcodes {
 
   public static void addGetPropertyNames(ClassVisitor cv, ClassMeta classMeta) {
 
-    MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "_ebean_getPropertyNames", "()[Ljava/lang/String;", null, null);
+    MethodVisitor mv = cv.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "_ebean_getPropertyNames", "()[Ljava/lang/String;", null, null);
     mv.visitCode();
     Label l0 = new Label();
     mv.visitLabel(l0);
@@ -88,7 +88,7 @@ public class IndexFieldWeaver implements Opcodes {
   }
 
   public static void addGetPropertyName(ClassVisitor cv, ClassMeta classMeta) {
-    MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "_ebean_getPropertyName", "(I)Ljava/lang/String;", null, null);
+    MethodVisitor mv = cv.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "_ebean_getPropertyName", "(I)Ljava/lang/String;", null, null);
     mv.visitCode();
     Label l0 = new Label();
     mv.visitLabel(l0);
@@ -176,9 +176,9 @@ public class IndexFieldWeaver implements Opcodes {
 
     MethodVisitor mv;
     if (intercept) {
-      mv = cv.visitMethod(ACC_PUBLIC, "_ebean_getFieldIntercept", "(I)Ljava/lang/Object;",null, null);
+      mv = cv.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "_ebean_getFieldIntercept", "(I)Ljava/lang/Object;",null, null);
     } else {
-      mv = cv.visitMethod(ACC_PUBLIC, "_ebean_getField", "(I)Ljava/lang/Object;", null, null);
+      mv = cv.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "_ebean_getField", "(I)Ljava/lang/Object;", null, null);
     }
 
     mv.visitCode();
@@ -249,10 +249,10 @@ public class IndexFieldWeaver implements Opcodes {
 
     MethodVisitor mv;
     if (intercept) {
-      mv = cv.visitMethod(ACC_PUBLIC, "_ebean_setFieldIntercept", "(ILjava/lang/Object;)V",
+      mv = cv.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "_ebean_setFieldIntercept", "(ILjava/lang/Object;)V",
         null, null);
     } else {
-      mv = cv.visitMethod(ACC_PUBLIC, "_ebean_setField", "(ILjava/lang/Object;)V", null, null);
+      mv = cv.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "_ebean_setField", "(ILjava/lang/Object;)V", null, null);
     }
 
     mv.visitCode();

--- a/src/main/java/io/ebean/enhance/entity/IndexFieldWeaver.java
+++ b/src/main/java/io/ebean/enhance/entity/IndexFieldWeaver.java
@@ -25,7 +25,7 @@ public class IndexFieldWeaver implements Opcodes {
   private static final String _EBEAN_PROPS = "_ebean_props";
 
   public static void addPropertiesField(ClassVisitor cv) {
-    FieldVisitor fv = cv.visitField(ACC_PUBLIC + ACC_STATIC, _EBEAN_PROPS, "[Ljava/lang/String;", null, null);
+    FieldVisitor fv = cv.visitField(ACC_PUBLIC + ACC_STATIC + ACC_SYNTHETIC, _EBEAN_PROPS, "[Ljava/lang/String;", null, null);
     fv.visitEnd();
   }
 

--- a/src/main/java/io/ebean/enhance/entity/InterceptField.java
+++ b/src/main/java/io/ebean/enhance/entity/InterceptField.java
@@ -17,7 +17,7 @@ public class InterceptField implements Opcodes, EnhanceConstants {
   */
   public static void addField(ClassVisitor cv, boolean transientInternalFields) {
 
-    int access = ACC_PROTECTED + (transientInternalFields ? ACC_TRANSIENT : 0);
+    int access = ACC_PROTECTED + (transientInternalFields ? ACC_TRANSIENT : 0) + ACC_SYNTHETIC;
     FieldVisitor f1 = cv.visitField(access, INTERCEPT_FIELD, L_INTERCEPT, null, null);
     f1.visitEnd();
   }

--- a/src/main/java/io/ebean/enhance/entity/InterceptField.java
+++ b/src/main/java/io/ebean/enhance/entity/InterceptField.java
@@ -38,7 +38,7 @@ public class InterceptField implements Opcodes, EnhanceConstants {
     MethodVisitor mv;
     Label l0, l1;
 
-    mv = cv.visitMethod(ACC_PUBLIC, "_ebean_getIntercept", "()" + L_INTERCEPT, null, null);
+    mv = cv.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "_ebean_getIntercept", "()" + L_INTERCEPT, null, null);
     mv.visitCode();
     l0 = new Label();
     mv.visitLabel(l0);
@@ -75,7 +75,7 @@ public class InterceptField implements Opcodes, EnhanceConstants {
   */
   private static void addInitInterceptMethod(ClassVisitor cv, String className) {
 
-    MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "_ebean_intercept", "()" + L_INTERCEPT, null, null);
+    MethodVisitor mv = cv.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "_ebean_intercept", "()" + L_INTERCEPT, null, null);
     mv.visitCode();
     Label l0 = new Label();
     mv.visitLabel(l0);

--- a/src/main/java/io/ebean/enhance/entity/MarkerField.java
+++ b/src/main/java/io/ebean/enhance/entity/MarkerField.java
@@ -48,7 +48,7 @@ public class MarkerField implements Opcodes, EnhanceConstants {
 
     MethodVisitor mv;
 
-    mv = cv.visitMethod(ACC_PUBLIC, "_ebean_getMarker", "()Ljava/lang/String;", null, null);
+    mv = cv.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "_ebean_getMarker", "()Ljava/lang/String;", null, null);
     mv.visitCode();
     Label l0 = new Label();
     mv.visitLabel(l0);

--- a/src/main/java/io/ebean/enhance/entity/MarkerField.java
+++ b/src/main/java/io/ebean/enhance/entity/MarkerField.java
@@ -28,7 +28,7 @@ public class MarkerField implements Opcodes, EnhanceConstants {
 
     String cn = className.replace('/', '.');
 
-    FieldVisitor fv = cv.visitField(ACC_PRIVATE + ACC_STATIC, _EBEAN_MARKER, "Ljava/lang/String;", null, cn);
+    FieldVisitor fv = cv.visitField(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, _EBEAN_MARKER, "Ljava/lang/String;", null, cn);
     fv.visitEnd();
 
     return cn;

--- a/src/main/java/io/ebean/enhance/entity/MethodEquals.java
+++ b/src/main/java/io/ebean/enhance/entity/MethodEquals.java
@@ -60,7 +60,7 @@ public class MethodEquals implements Opcodes, EnhanceConstants {
   */
   public static void addIdentityField(ClassVisitor cv) {
 
-      int access = ACC_PROTECTED + ACC_TRANSIENT;
+      int access = ACC_PROTECTED + ACC_TRANSIENT + ACC_SYNTHETIC;
     FieldVisitor f0 = cv.visitField(access, IDENTITY_FIELD, "Ljava/lang/Object;", null, null);
     f0.visitEnd();
   }

--- a/src/main/java/io/ebean/enhance/entity/MethodEquals.java
+++ b/src/main/java/io/ebean/enhance/entity/MethodEquals.java
@@ -98,7 +98,7 @@ public class MethodEquals implements Opcodes, EnhanceConstants {
 
     MethodVisitor mv;
 
-    mv = cv.visitMethod(ACC_PRIVATE, _EBEAN_GET_IDENTITY, "()Ljava/lang/Object;", null, null);
+    mv = cv.visitMethod(ACC_PRIVATE + ACC_SYNTHETIC, _EBEAN_GET_IDENTITY, "()Ljava/lang/Object;", null, null);
     mv.visitCode();
     Label l0 = new Label();
     Label l1 = new Label();
@@ -210,7 +210,7 @@ public class MethodEquals implements Opcodes, EnhanceConstants {
 
     MethodVisitor mv;
 
-    mv = cv.visitMethod(ACC_PRIVATE, _EBEAN_GET_IDENTITY, "()Ljava/lang/Object;", null, null);
+    mv = cv.visitMethod(ACC_PRIVATE + ACC_SYNTHETIC, _EBEAN_GET_IDENTITY, "()Ljava/lang/Object;", null, null);
     mv.visitCode();
     Label l0 = new Label();
     Label l1 = new Label();
@@ -319,7 +319,7 @@ public class MethodEquals implements Opcodes, EnhanceConstants {
 
     MethodVisitor mv;
 
-    mv = cv.visitMethod(ACC_PUBLIC, "equals", "(Ljava/lang/Object;)Z", null, null);
+    mv = cv.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "equals", "(Ljava/lang/Object;)Z", null, null);
     mv.visitCode();
     Label l0 = new Label();
     mv.visitLabel(l0);
@@ -390,7 +390,7 @@ public class MethodEquals implements Opcodes, EnhanceConstants {
 
     MethodVisitor mv;
 
-    mv = cv.visitMethod(ACC_PUBLIC, "hashCode", "()I", null, null);
+    mv = cv.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "hashCode", "()I", null, null);
     mv.visitCode();
     Label l0 = new Label();
     mv.visitLabel(l0);

--- a/src/main/java/io/ebean/enhance/entity/MethodIsEmbeddedNewOrDirty.java
+++ b/src/main/java/io/ebean/enhance/entity/MethodIsEmbeddedNewOrDirty.java
@@ -36,7 +36,7 @@ public class MethodIsEmbeddedNewOrDirty implements Opcodes, EnhanceConstants {
 
     MethodVisitor mv;
 
-    mv = cv.visitMethod(ACC_PUBLIC, "_ebean_isEmbeddedNewOrDirty", "()Z", null, null);
+    mv = cv.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "_ebean_isEmbeddedNewOrDirty", "()Z", null, null);
     mv.visitCode();
 
     Label labelBegin = null;

--- a/src/main/java/io/ebean/enhance/entity/MethodNewInstance.java
+++ b/src/main/java/io/ebean/enhance/entity/MethodNewInstance.java
@@ -19,7 +19,7 @@ public class MethodNewInstance {
   */
   public static void addMethod(ClassVisitor cv, ClassMeta classMeta) {
 
-    MethodVisitor mv = cv.visitMethod(Opcodes.ACC_PUBLIC, "_ebean_newInstance", "()Ljava/lang/Object;", null, null);
+    MethodVisitor mv = cv.visitMethod(Opcodes.ACC_PUBLIC + Opcodes.ACC_SYNTHETIC, "_ebean_newInstance", "()Ljava/lang/Object;", null, null);
     mv.visitCode();
     Label l0 = new Label();
     mv.visitLabel(l0);

--- a/src/main/java/io/ebean/enhance/entity/MethodSetEmbeddedLoaded.java
+++ b/src/main/java/io/ebean/enhance/entity/MethodSetEmbeddedLoaded.java
@@ -30,7 +30,7 @@ public class MethodSetEmbeddedLoaded implements Opcodes, EnhanceConstants {
 
     MethodVisitor mv;
 
-    mv = cv.visitMethod(ACC_PUBLIC, "_ebean_setEmbeddedLoaded", NOARG_VOID, null, null);
+    mv = cv.visitMethod(ACC_PUBLIC + ACC_SYNTHETIC, "_ebean_setEmbeddedLoaded", NOARG_VOID, null, null);
     mv.visitCode();
 
     Label labelBegin = null;

--- a/src/main/java/io/ebean/enhance/transactional/ClassAdapterTransactional.java
+++ b/src/main/java/io/ebean/enhance/transactional/ClassAdapterTransactional.java
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
 
 import static io.ebean.enhance.asm.Opcodes.ACC_PRIVATE;
 import static io.ebean.enhance.asm.Opcodes.ACC_STATIC;
+import static io.ebean.enhance.asm.Opcodes.ACC_SYNTHETIC;
 import static io.ebean.enhance.asm.Opcodes.BIPUSH;
 import static io.ebean.enhance.asm.Opcodes.INVOKESTATIC;
 import static io.ebean.enhance.asm.Opcodes.PUTSTATIC;
@@ -271,17 +272,17 @@ public class ClassAdapterTransactional extends ClassVisitor {
 
   private void addStaticFieldDefinitions() {
     for (int i = 0; i < queryProfileCount; i++) {
-      FieldVisitor fv = cv.visitField(ACC_PRIVATE + ACC_STATIC, QP_FIELD_PREFIX + i, "Lio/ebean/ProfileLocation;", null, null);
+      FieldVisitor fv = cv.visitField(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, QP_FIELD_PREFIX + i, "Lio/ebean/ProfileLocation;", null, null);
       fv.visitEnd();
     }
     for (int i = 0; i < transactionProfileCount; i++) {
-      FieldVisitor fv = cv.visitField(ACC_PRIVATE + ACC_STATIC, TX_FIELD_PREFIX + i, "Lio/ebean/ProfileLocation;", null, null);
+      FieldVisitor fv = cv.visitField(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, TX_FIELD_PREFIX + i, "Lio/ebean/ProfileLocation;", null, null);
       fv.visitEnd();
     }
   }
 
   private void addStaticFieldInitialisers() {
-    MethodVisitor mv = cv.visitMethod(ACC_PRIVATE + ACC_STATIC, "_$initProfileLocations", NOARG_VOID, null, null);
+    MethodVisitor mv = cv.visitMethod(ACC_PRIVATE + ACC_STATIC + ACC_SYNTHETIC, "_$initProfileLocations", NOARG_VOID, null, null);
     mv.visitCode();
 
     for (int i = 0; i < queryProfileCount; i++) {

--- a/src/main/java/io/ebean/enhance/transactional/MethodAdapter.java
+++ b/src/main/java/io/ebean/enhance/transactional/MethodAdapter.java
@@ -63,7 +63,7 @@ class MethodAdapter extends ConstructorMethodAdapter implements EnhanceConstants
 
   @Override
   public void visitCode() {
-    finallyVisitCode();;
+    finallyVisitCode();
   }
 
   @Override


### PR DESCRIPTION
As described in #112 the coverage report looks considerably more accurate now. I have not touched clinit and init prepended code, which will sometimes light up the packate declaration (line 1) in the coverage report.

QueryBean Enhancement hasn't been affected either, as the `@Generated` annotation on those classes is also included in Jacoco Filters.