### PR TITLE
FIX: Merge @Transactional if it is used at class and method level

### DIFF
--- a/src/main/java/io/ebean/enhance/common/AnnotationInfo.java
+++ b/src/main/java/io/ebean/enhance/common/AnnotationInfo.java
@@ -2,6 +2,7 @@ package io.ebean.enhance.common;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 /**
  * Collects the annotation information.
@@ -35,20 +36,20 @@ public class AnnotationInfo {
   }
 
   /**
+   * Gets or creates a list for the given prefix, it will hold the array values.
+   */
+  public List<Object> getArrayEntry(String prefix) {
+    return (List<Object>) valueMap.computeIfAbsent(prefix, k -> new ArrayList<>());
+  }
+  
+  /**
   * Add a annotation value.
   */
   @SuppressWarnings("unchecked")
   public void add(String prefix, String name, Object value){
     if (name == null){
       // this is an array value...
-      ArrayList<Object> list = (ArrayList<Object>)valueMap.get(prefix);
-      if (list == null){
-        list = new ArrayList<>();
-        valueMap.put(prefix, list);
-      }
-      //System.out.println("addArrayValue "+prefix+" value:"+value);
-      list.add(value);
-
+      getArrayEntry(prefix).add(value);
     } else {
       String key = getKey(prefix, name);
       //System.out.println("addValue "+key+" value:"+value);

--- a/src/main/java/io/ebean/enhance/common/AnnotationInfoVisitor.java
+++ b/src/main/java/io/ebean/enhance/common/AnnotationInfoVisitor.java
@@ -16,6 +16,9 @@ public class AnnotationInfoVisitor extends AnnotationVisitor {
     super(Opcodes.ASM7, av);
     this.info = info;
     this.prefix = prefix;
+    if (prefix != null) {
+      info.getArrayEntry(prefix); // register as empty
+    }
   }
 
   @Override

--- a/src/main/java/io/ebean/enhance/common/ClassMeta.java
+++ b/src/main/java/io/ebean/enhance/common/ClassMeta.java
@@ -411,10 +411,10 @@ public class ClassMeta {
 
     @Override
     public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-      if (mv == null) {
-        return null;
+      AnnotationVisitor av = null;
+      if (mv != null) {
+        av = mv.visitAnnotation(desc, visible);
       }
-      AnnotationVisitor av = mv.visitAnnotation(desc, visible);
       return new AnnotationInfoVisitor(null, methodMeta.getAnnotationInfo(), av);
     }
 

--- a/src/test/java/test/enhancement/ClassMetaReaderTest.java
+++ b/src/test/java/test/enhancement/ClassMetaReaderTest.java
@@ -1,9 +1,13 @@
 package test.enhancement;
 
+import java.io.IOException;
 import java.net.URL;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
+import io.ebean.annotation.Transactional;
+import io.ebean.enhance.asm.Type;
 import io.ebean.enhance.common.AgentManifest;
 import io.ebean.enhance.common.AnnotationInfo;
 import io.ebean.enhance.common.ClassMetaCache;
@@ -14,6 +18,7 @@ import io.ebean.enhance.common.ClassMetaReader;
 import io.ebean.enhance.entity.ClassPathClassBytesReader;
 import io.ebean.enhance.common.EnhanceContext;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.*;
 
 public class ClassMetaReaderTest {
@@ -84,6 +89,96 @@ public class ClassMetaReaderTest {
     assertEquals(annotationInfo.getValue("batchSize"), Integer.valueOf(50));
   }
 
+  private ClassMeta getClassMetaForOverrideTests() throws ClassNotFoundException {
+    ClassMetaReader classMetaReader = createClassMetaReader();
+
+    ClassLoader classLoader = this.getClass().getClassLoader();
+    ClassMeta classMeta = classMetaReader.get(true, "test.model.SomeTransactionalWithOverride", classLoader);
+    assertNotNull(classMeta);
+    return classMeta;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void checkClassOverrideCls() throws ClassNotFoundException {
+
+    ClassMeta classMeta = getClassMetaForOverrideTests();
+
+    // check class meta annotation
+    AnnotationInfo classAi = classMeta.getAnnotationInfo();
+    assertThat(classAi.getValue("batchSize")).isEqualTo(42);
+    assertThat((List<Type>) (classAi.getValue("rollbackFor")))
+      .containsExactly(Type.getType(IOException.class), Type.getType(IllegalStateException.class));
+
+
+  }
+  
+  @Test
+  public void checkClassOverrideMethod1() throws ClassNotFoundException {
+    ClassMeta classMeta = getClassMetaForOverrideTests();
+
+    // Method1 has no annotation, so it must take the annotation from class level
+    AnnotationInfo methodAi = classMeta.getInterfaceTransactionalInfo("someMethod1", "()V");
+    assertThat(methodAi.getValue("batchSize")).isEqualTo(42);
+    assertThat((List<Type>) (methodAi.getValue("rollbackFor")))
+      .containsExactly(Type.getType(IOException.class), Type.getType(IllegalStateException.class));
+  }
+
+  @Test
+  public void checkClassOverrideMethod2() throws ClassNotFoundException {
+    ClassMeta classMeta = getClassMetaForOverrideTests();
+
+    // Method2 has @Transactional(rollbackFor = ArrayIndexOutOfBoundsException.class)
+    AnnotationInfo methodAi = classMeta.getInterfaceTransactionalInfo("someMethod2", "()V");
+    assertThat(methodAi.getValue("batchSize")).isEqualTo(42);
+    assertThat((List<Type>) (methodAi.getValue("rollbackFor")))
+      .containsExactly(Type.getType(ArrayIndexOutOfBoundsException.class));
+  }
+
+  @Test
+  public void checkClassOverrideMethod3() throws ClassNotFoundException {
+    ClassMeta classMeta = getClassMetaForOverrideTests();
+
+    // Method3 has @Transactional(rollbackFor = {})
+    AnnotationInfo methodAi = classMeta.getInterfaceTransactionalInfo("someMethod3", "()V");
+    assertThat(methodAi.getValue("batchSize")).isEqualTo(42);
+    assertThat((List<Type>) (methodAi.getValue("rollbackFor"))).isEmpty();
+  }
+
+  
+  @Test
+  public void checkClassOverrideMethod4() throws ClassNotFoundException {
+    ClassMeta classMeta = getClassMetaForOverrideTests();
+
+    // Method4 has @Transactional(batchSize = 23)
+    AnnotationInfo methodAi = classMeta.getInterfaceTransactionalInfo("someMethod4", "()V");
+    assertThat(methodAi.getValue("batchSize")).isEqualTo(23);
+    assertThat((List<Type>) (methodAi.getValue("rollbackFor")))
+      .containsExactly(Type.getType(IOException.class), Type.getType(IllegalStateException.class));
+  }
+
+  
+  @Test
+  public void checkClassOverrideMethod5() throws ClassNotFoundException {
+    ClassMeta classMeta = getClassMetaForOverrideTests();
+
+    // Method5 has @Transactional
+    AnnotationInfo methodAi = classMeta.getInterfaceTransactionalInfo("someMethod5", "()V");
+    assertThat(methodAi.getValue("batchSize")).isEqualTo(42);
+    assertThat((List<Type>) (methodAi.getValue("rollbackFor")))
+      .containsExactly(Type.getType(IOException.class), Type.getType(IllegalStateException.class));
+  }
+
+  @Test
+  public void checkClassOverrideMethod6() throws ClassNotFoundException {
+    ClassMeta classMeta = getClassMetaForOverrideTests();
+
+    // Method5 has @Transactional
+    AnnotationInfo methodAi = classMeta.getInterfaceTransactionalInfo("someMethod6", "()V");
+    assertThat(methodAi.getValue("batchSize")).isEqualTo(0);
+    assertThat((List<Type>) (methodAi.getValue("rollbackFor"))).isEmpty();
+  }
+  
   @Test
   public void testEnhanceContext() {
 

--- a/src/test/java/test/model/SomeTransactionalWithOverride.java
+++ b/src/test/java/test/model/SomeTransactionalWithOverride.java
@@ -1,0 +1,40 @@
+package test.model;
+
+import java.io.IOException;
+
+import io.ebean.Ebean;
+import io.ebean.annotation.Transactional;
+import io.ebeaninternal.api.SpiTransaction;
+
+@Transactional(rollbackFor = { IOException.class, IllegalStateException.class }, batchSize = 42)
+public class SomeTransactionalWithOverride {
+
+  public void someMethod1() {
+    // must inherit class level
+  }
+
+  @Transactional(rollbackFor = ArrayIndexOutOfBoundsException.class)
+  public void someMethod2() {
+    // merge result: rollbackFor = ArrayIndexOutOfBoundsException.class, batchSize = 42
+  }
+
+  @Transactional(rollbackFor = {})
+  public void someMethod3() {
+    // merge result: rollbackFor = {}, batchSize = 42
+  }
+
+  @Transactional(batchSize = 23)
+  public void someMethod4() {
+    // merge result: rollbackFor = { IOException.class, IllegalStateException.class }, batchSize = 23
+  }
+
+  @Transactional
+  public void someMethod5() {
+    // no merge - take class level annotation
+  }
+
+  @Transactional(rollbackFor = {}, batchSize = 0)
+  public void someMethod6() {
+    // complete merge - take method level annotation
+  }
+}


### PR DESCRIPTION
This PR fixes the behaviour, if @Transactional is used at method and class level.

This may change existing behaviour:

```java
@Transactional(rollbackFor = { Ex1.class, Ex2.class }, batchSize = 42)
public class MyClass {

  @Transactional(batchSize = 23)
  public void methodWithDifferentBatchSize() {
    // OLD: batchSize = 42, rollbackFor = Ex1, Ex2
    // NEW: batchSize = 23, rollbackFor = Ex1, Ex2 (values will be merged!)
  }

  @Transactional(rollbackFor = Ex3.class)
  public void methodWithDifferentBatchSize() {
    // OLD: batchSize = 42, rollbackFor = Ex1, Ex2
    // NEW: batchSize = 42, rollbackFor = Ex3 (values will be merged!)
  }
}
```
More examples in the test case.

I don't know if "merging" is a good idea, because `@Transactional(batchSize = 0)` is different to `@Transactional`, although the default of batchSize = 0.

(This bug was discovered, while writing a test case for #92 - so #92 is obsolete, if this is merged in)


