### PR TITLE
Support EntityBeanIntercept as an interface (InterceptReadWrite & InterceptReadOnly)

### DIFF
--- a/ebean-agent/pom.xml
+++ b/ebean-agent/pom.xml
@@ -22,7 +22,7 @@
 
   <properties>
     <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
-    <ebean.version>13.0.0</ebean.version>
+    <ebean.version>12.16.0</ebean.version>
 <!--    <ebean.version>13.0.1-SNAPSHOT</ebean.version>-->
   </properties>
 

--- a/ebean-agent/pom.xml
+++ b/ebean-agent/pom.xml
@@ -4,6 +4,7 @@
     <groupId>org.avaje</groupId>
     <artifactId>java8-oss</artifactId>
     <version>3.6</version>
+    <relativePath/>
   </parent>
 
   <groupId>io.ebean</groupId>
@@ -21,7 +22,8 @@
 
   <properties>
     <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
-    <ebean.version>12.9.0</ebean.version>
+    <ebean.version>13.0.0</ebean.version>
+<!--    <ebean.version>13.0.1-SNAPSHOT</ebean.version>-->
   </properties>
 
   <dependencies>

--- a/ebean-agent/src/main/java/io/ebean/enhance/common/ClassMeta.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/ClassMeta.java
@@ -398,6 +398,29 @@ public class ClassMeta {
     return enhanceContext.isToManyGetField();
   }
 
+  /**
+   * Return the EntityBeanIntercept type that will be new'ed up for the EntityBean.
+   * For version 140+ EntityBeanIntercept is an interface and instead we new up InterceptReadWrite.
+   */
+  public String interceptNew() {
+    return enhanceContext.interceptNew();
+  }
+
+  /**
+   * Invoke a method on EntityBeanIntercept.
+   * For version 140+ EntityBeanIntercept is an interface and this uses INVOKEINTERFACE.
+   */
+  public void visitMethodInsnIntercept(MethodVisitor mv, String name, String desc) {
+    enhanceContext.visitMethodInsnIntercept(mv, name, desc);
+  }
+
+  /**
+   * If 141+ Add InterceptReadOnly support.
+   */
+  public boolean interceptAddReadOnly() {
+    return enhanceContext.interceptAddReadOnly();
+  }
+
   private static final class MethodReader extends MethodVisitor {
 
     final MethodMeta methodMeta;

--- a/ebean-agent/src/main/java/io/ebean/enhance/common/EnhanceConstants.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/EnhanceConstants.java
@@ -42,7 +42,9 @@ public interface EnhanceConstants {
 
   String C_GROOVYOBJECT = "groovy/lang/GroovyObject";
 
-  String C_INTERCEPT = "io/ebean/bean/EntityBeanIntercept";
+  String C_INTERCEPT_I = "io/ebean/bean/EntityBeanIntercept";
+  String C_INTERCEPT_RW = "io/ebean/bean/InterceptReadWrite";
+  String C_INTERCEPT_RO = "io/ebean/bean/InterceptReadOnly";
 
   String C_BEANCOLLECTION = "io/ebean/bean/BeanCollection";
 

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/ClassAdapterEntity.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/ClassAdapterEntity.java
@@ -239,6 +239,7 @@ public class ClassAdapterEntity extends ClassVisitor implements EnhanceConstants
     MethodSetEmbeddedLoaded.addMethod(cv, classMeta);
     MethodIsEmbeddedNewOrDirty.addMethod(cv, classMeta);
     MethodNewInstance.addMethod(cv, classMeta);
+    MethodNewInstanceReadOnly.interceptAddReadOnly(cv, classMeta);
 
     // register with the agentContext
     enhanceContext.addClassMeta(classMeta);

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/ConstructorAdapter.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/ConstructorAdapter.java
@@ -178,11 +178,11 @@ class ConstructorAdapter extends MethodVisitor implements EnhanceConstants, Opco
     } else {
       // add the initialisation of the intercept object
       super.visitVarInsn(ALOAD, 0);
-      super.visitTypeInsn(NEW, C_INTERCEPT);
+      super.visitTypeInsn(NEW, meta.interceptNew());
       super.visitInsn(DUP);
       super.visitVarInsn(ALOAD, 0);
 
-      super.visitMethodInsn(INVOKESPECIAL, C_INTERCEPT, INIT, "(Ljava/lang/Object;)V", false);
+      super.visitMethodInsn(INVOKESPECIAL, meta.interceptNew(), INIT, "(Ljava/lang/Object;)V", false);
       super.visitFieldInsn(PUTFIELD, className, INTERCEPT_FIELD, EnhanceConstants.L_INTERCEPT);
 
       if (meta.isLog(8)) {

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/FieldMeta.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/FieldMeta.java
@@ -1,10 +1,6 @@
 package io.ebean.enhance.entity;
 
-import io.ebean.enhance.asm.ClassVisitor;
-import io.ebean.enhance.asm.Label;
-import io.ebean.enhance.asm.MethodVisitor;
-import io.ebean.enhance.asm.Opcodes;
-import io.ebean.enhance.asm.Type;
+import io.ebean.enhance.asm.*;
 import io.ebean.enhance.common.ClassMeta;
 import io.ebean.enhance.common.EnhanceConstants;
 import io.ebean.enhance.common.VisitUtil;
@@ -350,7 +346,7 @@ public class FieldMeta implements Opcodes, EnhanceConstants {
       mv.visitLineNumber(5, labelStart);
       mv.visitVarInsn(ALOAD, 0);
       mv.visitFieldInsn(GETFIELD, className, INTERCEPT_FIELD, L_INTERCEPT);
-      mv.visitMethodInsn(INVOKEVIRTUAL, C_INTERCEPT, "preGetId", NOARG_VOID, false);
+      classMeta.visitMethodInsnIntercept(mv, "preGetId", NOARG_VOID);
 
     } else if (isInterceptGet()) {
       maxVars = 2;
@@ -360,7 +356,7 @@ public class FieldMeta implements Opcodes, EnhanceConstants {
       mv.visitVarInsn(ALOAD, 0);
       mv.visitFieldInsn(GETFIELD, className, INTERCEPT_FIELD, L_INTERCEPT);
       VisitUtil.visitIntInsn(mv, indexPosition);
-      mv.visitMethodInsn(INVOKEVIRTUAL, C_INTERCEPT, "preGetter", "(I)V", false);
+      classMeta.visitMethodInsnIntercept(mv, "preGetter", "(I)V");
     }
     if (labelStart == null) {
       labelStart = labelEnd;
@@ -387,7 +383,7 @@ public class FieldMeta implements Opcodes, EnhanceConstants {
     mv.visitVarInsn(ALOAD, 0);
     mv.visitFieldInsn(GETFIELD, className, INTERCEPT_FIELD, L_INTERCEPT);
     VisitUtil.visitIntInsn(mv, indexPosition);
-    mv.visitMethodInsn(INVOKEVIRTUAL, C_INTERCEPT, "preGetter", "(I)V", false);
+    classMeta.visitMethodInsnIntercept(mv, "preGetter", "(I)V");
 
     Label l4 = new Label();
     if (classMeta.getEnhanceContext().isCheckNullManyFields()) {
@@ -415,7 +411,7 @@ public class FieldMeta implements Opcodes, EnhanceConstants {
       mv.visitVarInsn(ALOAD, 0);
       mv.visitFieldInsn(GETFIELD, className, INTERCEPT_FIELD, L_INTERCEPT);
       VisitUtil.visitIntInsn(mv, indexPosition);
-      mv.visitMethodInsn(INVOKEVIRTUAL, C_INTERCEPT, "initialisedMany", "(I)V", false);
+      classMeta.visitMethodInsnIntercept(mv, "initialisedMany", "(I)V");
 
       if (isManyToMany() || hasOrderColumn()) {
         // turn on modify listening for ManyToMany
@@ -514,7 +510,7 @@ public class FieldMeta implements Opcodes, EnhanceConstants {
     if (isToMany()) {
       preSetterMethod = "preSetterMany";
     }
-    mv.visitMethodInsn(INVOKEVIRTUAL, C_INTERCEPT, preSetterMethod, "(ZI" + preSetterArgTypes + ")V", false);
+    classMeta.visitMethodInsnIntercept(mv, preSetterMethod, "(ZI" + preSetterArgTypes + ")V");
     Label l1 = new Label();
     mv.visitLabel(l1);
     mv.visitLineNumber(2, l1);
@@ -563,7 +559,7 @@ public class FieldMeta implements Opcodes, EnhanceConstants {
     mv.visitVarInsn(ALOAD, 0);
     mv.visitFieldInsn(GETFIELD, fieldClass, INTERCEPT_FIELD, L_INTERCEPT);
     VisitUtil.visitIntInsn(mv, indexPosition);
-    mv.visitMethodInsn(INVOKEVIRTUAL, C_INTERCEPT, "setLoadedProperty", "(I)V", false);
+    classMeta.visitMethodInsnIntercept(mv, "setLoadedProperty", "(I)V");
 
     Label l2 = new Label();
     mv.visitLabel(l2);

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/InterceptField.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/InterceptField.java
@@ -88,10 +88,10 @@ class InterceptField implements Opcodes, EnhanceConstants {
     mv.visitLabel(l2);
     mv.visitLineNumber(2, l2);
     mv.visitVarInsn(ALOAD, 0);
-    mv.visitTypeInsn(NEW, C_INTERCEPT);
+    mv.visitTypeInsn(NEW, meta.interceptNew());
     mv.visitInsn(DUP);
     mv.visitVarInsn(ALOAD, 0);
-    mv.visitMethodInsn(INVOKESPECIAL, C_INTERCEPT, INIT, "(Ljava/lang/Object;)V", false);
+    mv.visitMethodInsn(INVOKESPECIAL, meta.interceptNew(), INIT, "(Ljava/lang/Object;)V", false);
     mv.visitFieldInsn(PUTFIELD, className, INTERCEPT_FIELD, L_INTERCEPT);
     mv.visitLabel(l1);
     mv.visitLineNumber(3, l1);

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/MethodIsEmbeddedNewOrDirty.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/MethodIsEmbeddedNewOrDirty.java
@@ -65,7 +65,7 @@ class MethodIsEmbeddedNewOrDirty implements Opcodes, EnhanceConstants {
         mv.visitFieldInsn(GETFIELD, className, INTERCEPT_FIELD, L_INTERCEPT);
         mv.visitVarInsn(ALOAD, 0);
         fieldMeta.appendSwitchGet(mv, classMeta, false);
-        mv.visitMethodInsn(INVOKEVIRTUAL, C_INTERCEPT, "isEmbeddedNewOrDirty", "(Ljava/lang/Object;)Z", false);
+        classMeta.visitMethodInsnIntercept(mv, "isEmbeddedNewOrDirty", "(Ljava/lang/Object;)Z");
 
         labelNext = new Label();
         mv.visitJumpInsn(IFEQ, labelNext);

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/MethodNewInstanceReadOnly.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/MethodNewInstanceReadOnly.java
@@ -1,0 +1,96 @@
+package io.ebean.enhance.entity;
+
+import io.ebean.enhance.asm.ClassVisitor;
+import io.ebean.enhance.asm.Label;
+import io.ebean.enhance.asm.MethodVisitor;
+import io.ebean.enhance.common.ClassMeta;
+import io.ebean.enhance.common.EnhanceConstants;
+
+import static io.ebean.enhance.asm.Opcodes.*;
+import static io.ebean.enhance.common.EnhanceConstants.*;
+
+/**
+ * Add support for the InterceptReadOnly implementation of EntityBeanIntercept.
+ */
+class MethodNewInstanceReadOnly {
+
+  static void interceptAddReadOnly(ClassVisitor cv, ClassMeta meta) {
+    if (!meta.interceptAddReadOnly()) {
+      return;
+    }
+    if (meta.isSuperClassEntity()) {
+      add_initSuper(cv, meta);
+    } else {
+      add_initLocal(cv, meta);
+    }
+    add_newInstanceReadOnly(cv, meta);
+  }
+
+  static void add_newInstanceReadOnly(ClassVisitor cv, ClassMeta meta) {
+    MethodVisitor mv = cv.visitMethod(ACC_PUBLIC, "_ebean_newInstanceReadOnly", "()Ljava/lang/Object;", null, null);
+    mv.visitCode();
+    Label label0 = new Label();
+    mv.visitLabel(label0);
+    mv.visitLineNumber(4, label0);
+    mv.visitTypeInsn(NEW, meta.getClassName());
+    mv.visitInsn(DUP);
+    mv.visitInsn(ACONST_NULL);
+    mv.visitMethodInsn(INVOKESPECIAL, meta.getClassName(), INIT, "(L" + C_ENTITYBEAN + ";)V", false);
+    mv.visitInsn(ARETURN);
+    Label label1 = new Label();
+    mv.visitLabel(label1);
+    mv.visitLocalVariable("this", "L" + meta.getClassName() + ";", null, label0, label1, 0);
+    mv.visitMaxs(3, 1);
+    mv.visitEnd();
+  }
+
+  static void add_initSuper(ClassVisitor cv, ClassMeta meta) {
+    MethodVisitor mv = cv.visitMethod(ACC_PROTECTED, "<init>", "(L" + C_ENTITYBEAN + ";)V", null, null);
+    mv.visitCode();
+    Label label0 = new Label();
+    mv.visitLabel(label0);
+    mv.visitLineNumber(12, label0);
+    mv.visitVarInsn(ALOAD, 0);
+    mv.visitVarInsn(ALOAD, 1);
+    mv.visitMethodInsn(INVOKESPECIAL, meta.getSuperClassName(), "<init>", "(L" + C_ENTITYBEAN + ";)V", false);
+    Label label1 = new Label();
+    mv.visitLabel(label1);
+    mv.visitLineNumber(13, label1);
+    mv.visitInsn(RETURN);
+    Label label2 = new Label();
+    mv.visitLabel(label2);
+    mv.visitLocalVariable("this", "L" + meta.getClassName() + ";", null, label0, label2, 0);
+    mv.visitLocalVariable("ignore", "L" + C_ENTITYBEAN + ";", null, label0, label2, 1);
+    mv.visitMaxs(2, 2);
+    mv.visitEnd();
+  }
+
+  static void add_initLocal(ClassVisitor cv, ClassMeta meta) {
+    MethodVisitor mv = cv.visitMethod(ACC_PROTECTED, "<init>", "(L" + C_ENTITYBEAN + ";)V", null, null);
+    mv.visitCode();
+    Label label0 = new Label();
+    mv.visitLabel(label0);
+    mv.visitLineNumber(2, label0);
+    mv.visitVarInsn(ALOAD, 0);
+    mv.visitMethodInsn(INVOKESPECIAL, meta.getSuperClassName(), "<init>", "()V", false);
+    Label label1 = new Label();
+    mv.visitLabel(label1);
+    mv.visitLineNumber(3, label1);
+    mv.visitVarInsn(ALOAD, 0);
+    mv.visitTypeInsn(NEW, C_INTERCEPT_RO);
+    mv.visitInsn(DUP);
+    mv.visitVarInsn(ALOAD, 0);
+    mv.visitMethodInsn(INVOKESPECIAL, C_INTERCEPT_RO, "<init>", "(Ljava/lang/Object;)V", false);
+    mv.visitFieldInsn(PUTFIELD, meta.getClassName(), INTERCEPT_FIELD, EnhanceConstants.L_INTERCEPT);
+    Label label2 = new Label();
+    mv.visitLabel(label2);
+    mv.visitLineNumber(25, label2);
+    mv.visitInsn(RETURN);
+    Label label3 = new Label();
+    mv.visitLabel(label3);
+    mv.visitLocalVariable("this", "L" + meta.getClassName() + ";", null, label0, label3, 0);
+    mv.visitLocalVariable("ignore", "L" + C_ENTITYBEAN + ";", null, label0, label3, 1);
+    mv.visitMaxs(4, 2);
+    mv.visitEnd();
+  }
+}

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/MethodSetEmbeddedLoaded.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/MethodSetEmbeddedLoaded.java
@@ -49,7 +49,7 @@ class MethodSetEmbeddedLoaded implements Opcodes, EnhanceConstants {
         mv.visitFieldInsn(GETFIELD, className, INTERCEPT_FIELD, L_INTERCEPT);
         mv.visitVarInsn(ALOAD, 0);
         fieldMeta.appendSwitchGet(mv, classMeta, false);
-        mv.visitMethodInsn(INVOKEVIRTUAL, C_INTERCEPT, "setEmbeddedLoaded", "(Ljava/lang/Object;)V", false);
+        classMeta.visitMethodInsnIntercept(mv, "setEmbeddedLoaded", "(Ljava/lang/Object;)V");
       }
     }
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -6,6 +6,7 @@
     <groupId>org.avaje</groupId>
     <artifactId>java8-oss</artifactId>
     <version>3.6</version>
+    <relativePath/>
   </parent>
 
   <groupId>io.ebean</groupId>
@@ -16,7 +17,8 @@
 
   <properties>
     <ebean.agent.version>13.0.1-SNAPSHOT</ebean.agent.version>
-    <ebean.version>12.9.0</ebean.version>
+    <ebean.version>13.0.0</ebean.version>
+<!--    <ebean.version>13.0.1-SNAPSHOT</ebean.version>-->
   </properties>
 
   <dependencies>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -17,7 +17,7 @@
 
   <properties>
     <ebean.agent.version>13.0.1-SNAPSHOT</ebean.agent.version>
-    <ebean.version>13.0.0</ebean.version>
+    <ebean.version>12.16.0</ebean.version>
 <!--    <ebean.version>13.0.1-SNAPSHOT</ebean.version>-->
   </properties>
 

--- a/test/src/test/java/io/ebean/enhance/common/AgentManifestTest.java
+++ b/test/src/test/java/io/ebean/enhance/common/AgentManifestTest.java
@@ -182,7 +182,7 @@ public class AgentManifestTest {
     assertThat(context.getTransactionalPackages()).containsOnly("org.foo");
     assertThat(context.getQuerybeanPackages()).containsOnly("org.foo");
 
-    assertThat(context.getPackagesSummary()).isEqualTo("packages entity:[org.foo.some.domain, org.foo.domain]  transactional:[org.foo]  querybean:[org.foo]  profileLocation:true");
+    assertThat(context.getPackagesSummary()).isEqualTo("packages entity:[org.foo.some.domain, org.foo.domain]  transactional:[org.foo]  querybean:[org.foo]  profileLocation:true  version:0");
 
     context.collectSummary();
     SummaryInfo emptySummary = context.getSummaryInfo();

--- a/test/src/test/java/io/ebean/example/EbiInterface.java
+++ b/test/src/test/java/io/ebean/example/EbiInterface.java
@@ -1,0 +1,10 @@
+package io.ebean.example;
+
+public interface EbiInterface {
+
+  void preGetId();
+
+  void preSetter(boolean b, int i, Long id, Long newValue);
+
+  boolean isEmbeddedNewOrDirty(Object foo);
+}

--- a/test/src/test/java/io/ebean/example/EbiReadOnly.java
+++ b/test/src/test/java/io/ebean/example/EbiReadOnly.java
@@ -1,0 +1,23 @@
+package io.ebean.example;
+
+public final class EbiReadOnly implements EbiInterface {
+
+  public EbiReadOnly(Object owner) {
+
+  }
+
+  @Override
+  public void preGetId() {
+
+  }
+
+  @Override
+  public void preSetter(boolean b, int i, Long id, Long newValue) {
+
+  }
+
+  @Override
+  public boolean isEmbeddedNewOrDirty(Object foo) {
+    return false;
+  }
+}

--- a/test/src/test/java/io/ebean/example/EbiReadWrite.java
+++ b/test/src/test/java/io/ebean/example/EbiReadWrite.java
@@ -1,0 +1,23 @@
+package io.ebean.example;
+
+public final class EbiReadWrite implements EbiInterface {
+
+  public EbiReadWrite(Object owner) {
+
+  }
+
+  @Override
+  public void preGetId() {
+
+  }
+
+  @Override
+  public void preSetter(boolean b, int i, Long id, Long newValue) {
+
+  }
+
+  @Override
+  public boolean isEmbeddedNewOrDirty(Object foo) {
+    return false;
+  }
+}

--- a/test/src/test/java/io/ebean/example/MyEntityBean.java
+++ b/test/src/test/java/io/ebean/example/MyEntityBean.java
@@ -9,141 +9,140 @@ import javax.persistence.Id;
 /**
  * Prototype bean for ASM bytecode generation.
  */
-public class MyEntityBean implements EntityBean {
+public class MyEntityBean {//implements EntityBean {
 
-  EntityBeanIntercept intercept;
-
-  @Id
-  Long id;
-
-  MyEmbeddedBean foo;
-  MyEmbeddedBean bar;
-
-  Long getId() {
-    return id;
-  }
-
-  public Long _ebean_get_id() {
-    intercept.preGetId();
-    return id;
-  }
-
-  public void _ebean_set_id(Long newValue) {
-    intercept.preSetter(true, 1, id, newValue);
-    this.id = newValue;
-  }
-
-  @Override
-  public String[] _ebean_getPropertyNames() {
-    return new String[0];
-  }
-
-  @Override
-  public String _ebean_getPropertyName(int pos) {
-    return null;
-  }
-
-  @Override
-  public String _ebean_getMarker() {
-    return null;
-  }
-
-  @Override
-  public Object _ebean_newInstance() {
-    return null;
-  }
-
-  @Override
-  public void _ebean_setEmbeddedLoaded() {
-
-  }
-
-  @Override
-  public boolean _ebean_isEmbeddedNewOrDirty() {
-    // for each embedded bean field...
-    if (intercept.isEmbeddedNewOrDirty(foo)) return true;
-    if (intercept.isEmbeddedNewOrDirty(bar)) return true;
-
-    return false;
- }
-
-  @Override
-  public EntityBeanIntercept _ebean_getIntercept() {
-    return null;
-  }
-
-  @Override
-  public EntityBeanIntercept _ebean_intercept() {
-    return null;
-  }
-
-  @Override
-  public void _ebean_setField(int fieldIndex, Object value) {
-
-    switch (fieldIndex) {
-      case 0:
-        _ebean_set_id((Long)value);
-        break;
-      case 1:
-        _ebean_set_id((Long)value);
-      default:
-        throw new RuntimeException("asd");
-    }
-  }
-
-  Object _ebean_identity;
-
-  public Object _ebean_getIdentity() {
-    synchronized (this) {
-      if (_ebean_identity != null) {
-        return _ebean_identity;
-      }
-
-      Object id = getId();
-      if (id != null) {
-        _ebean_identity = id;
-      } else {
-        _ebean_identity = new Object();
-      }
-
-      return _ebean_identity;
-    }
-  }
-
-  long intId;
-
-  public long getIntId() {
-    return intId;
-  }
-
-  public Object _ebean_getIdentity_primative() {
-    synchronized (this) {
-      if (_ebean_identity != null) {
-        return _ebean_identity;
-      }
-
-      if (getIntId() != 0) {
-        _ebean_identity = Long.valueOf(getIntId());
-      } else {
-        _ebean_identity = new Object();
-      }
-
-      return _ebean_identity;
-    }
-  }
-
-  @Override
-  public void _ebean_setFieldIntercept(int fieldIndex, Object value) {
-
-  }
-
-  @Override
-  public Object _ebean_getField(int fieldIndex) {
-    return null;
-  }
-
-  @Override
-  public Object _ebean_getFieldIntercept(int fieldIndex) {
-    return null;
-  }
+//  EntityBeanIntercept intercept;
+//
+//  @Id
+//  Long id;
+//
+//  MyEmbeddedBean foo;
+//  MyEmbeddedBean bar;
+//
+//  MyEntityBean() {
+//    intercept = new EntityBeanIntercept(this);
+//  }
+//
+//  Long getId() {
+//    return id;
+//  }
+//
+//  public Long _ebean_get_id() {
+//    intercept.preGetId();
+//    return id;
+//  }
+//
+//  public void _ebean_set_id(Long newValue) {
+//    intercept.preSetter(true, 1, id, newValue);
+//    this.id = newValue;
+//  }
+//
+//  @Override
+//  public String[] _ebean_getPropertyNames() {
+//    return new String[0];
+//  }
+//
+//  @Override
+//  public String _ebean_getPropertyName(int pos) {
+//    return null;
+//  }
+//
+//  @Override
+//  public Object _ebean_newInstance() {
+//    return null;
+//  }
+//
+//  @Override
+//  public void _ebean_setEmbeddedLoaded() {
+//
+//  }
+//
+//  @Override
+//  public boolean _ebean_isEmbeddedNewOrDirty() {
+//    // for each embedded bean field...
+//    if (intercept.isEmbeddedNewOrDirty(foo)) return true;
+//    if (intercept.isEmbeddedNewOrDirty(bar)) return true;
+//
+//    return false;
+// }
+//
+//  @Override
+//  public EntityBeanIntercept _ebean_getIntercept() {
+//    return null;
+//  }
+//
+//  @Override
+//  public EntityBeanIntercept _ebean_intercept() {
+//    return null;
+//  }
+//
+//  @Override
+//  public void _ebean_setField(int fieldIndex, Object value) {
+//
+//    switch (fieldIndex) {
+//      case 0:
+//        _ebean_set_id((Long)value);
+//        break;
+//      case 1:
+//        _ebean_set_id((Long)value);
+//      default:
+//        throw new RuntimeException("asd");
+//    }
+//  }
+//
+//  Object _ebean_identity;
+//
+//  public Object _ebean_getIdentity() {
+//    synchronized (this) {
+//      if (_ebean_identity != null) {
+//        return _ebean_identity;
+//      }
+//
+//      Object id = getId();
+//      if (id != null) {
+//        _ebean_identity = id;
+//      } else {
+//        _ebean_identity = new Object();
+//      }
+//
+//      return _ebean_identity;
+//    }
+//  }
+//
+//  long intId;
+//
+//  public long getIntId() {
+//    return intId;
+//  }
+//
+//  public Object _ebean_getIdentity_primative() {
+//    synchronized (this) {
+//      if (_ebean_identity != null) {
+//        return _ebean_identity;
+//      }
+//
+//      if (getIntId() != 0) {
+//        _ebean_identity = Long.valueOf(getIntId());
+//      } else {
+//        _ebean_identity = new Object();
+//      }
+//
+//      return _ebean_identity;
+//    }
+//  }
+//
+//  @Override
+//  public void _ebean_setFieldIntercept(int fieldIndex, Object value) {
+//
+//  }
+//
+//  @Override
+//  public Object _ebean_getField(int fieldIndex) {
+//    return null;
+//  }
+//
+//  @Override
+//  public Object _ebean_getFieldIntercept(int fieldIndex) {
+//    return null;
+//  }
 }

--- a/test/src/test/java/io/ebean/example/MyEntityBean2.java
+++ b/test/src/test/java/io/ebean/example/MyEntityBean2.java
@@ -1,0 +1,153 @@
+package io.ebean.example;
+
+import io.ebean.bean.EntityBean;
+import io.ebean.bean.EntityBeanIntercept;
+import test.model.MyEmbeddedBean;
+
+import javax.persistence.Id;
+
+public class MyEntityBean2 implements EntityBean {
+
+  EbiInterface intercept;
+
+  @Id
+  Long id;
+
+  MyEmbeddedBean foo;
+  MyEmbeddedBean bar;
+
+  public Object _ebean_newInstanceReadOnly() {
+    return new MyEntityBean2(null);
+  }
+
+  protected MyEntityBean2(EntityBean ignore) {
+    intercept = new EbiReadOnly(this);
+  }
+
+  MyEntityBean2() {
+    intercept = new EbiReadWrite(this);
+  }
+
+  Long getId() {
+    return id;
+  }
+
+  public Long _ebean_get_id() {
+    intercept.preGetId();
+    return id;
+  }
+
+  public void _ebean_set_id(Long newValue) {
+    intercept.preSetter(true, 1, id, newValue);
+    this.id = newValue;
+  }
+
+  @Override
+  public String[] _ebean_getPropertyNames() {
+    return new String[0];
+  }
+
+  @Override
+  public String _ebean_getPropertyName(int pos) {
+    return null;
+  }
+
+  @Override
+  public Object _ebean_newInstance() {
+    return null;
+  }
+
+  @Override
+  public void _ebean_setEmbeddedLoaded() {
+
+  }
+
+  @Override
+  public boolean _ebean_isEmbeddedNewOrDirty() {
+    // for each embedded bean field...
+    if (intercept.isEmbeddedNewOrDirty(foo)) return true;
+    if (intercept.isEmbeddedNewOrDirty(bar)) return true;
+
+    return false;
+ }
+
+  @Override
+  public EntityBeanIntercept _ebean_getIntercept() {
+    return null;
+  }
+
+  @Override
+  public EntityBeanIntercept _ebean_intercept() {
+    return null;
+  }
+
+  @Override
+  public void _ebean_setField(int fieldIndex, Object value) {
+
+    switch (fieldIndex) {
+      case 0:
+        _ebean_set_id((Long)value);
+        break;
+      case 1:
+        _ebean_set_id((Long)value);
+      default:
+        throw new RuntimeException("asd");
+    }
+  }
+
+  Object _ebean_identity;
+
+  public Object _ebean_getIdentity() {
+    synchronized (this) {
+      if (_ebean_identity != null) {
+        return _ebean_identity;
+      }
+
+      Object id = getId();
+      if (id != null) {
+        _ebean_identity = id;
+      } else {
+        _ebean_identity = new Object();
+      }
+
+      return _ebean_identity;
+    }
+  }
+
+  long intId;
+
+  public long getIntId() {
+    return intId;
+  }
+
+  public Object _ebean_getIdentity_primative() {
+    synchronized (this) {
+      if (_ebean_identity != null) {
+        return _ebean_identity;
+      }
+
+      if (getIntId() != 0) {
+        _ebean_identity = Long.valueOf(getIntId());
+      } else {
+        _ebean_identity = new Object();
+      }
+
+      return _ebean_identity;
+    }
+  }
+
+  @Override
+  public void _ebean_setFieldIntercept(int fieldIndex, Object value) {
+
+  }
+
+  @Override
+  public Object _ebean_getField(int fieldIndex) {
+    return null;
+  }
+
+  @Override
+  public Object _ebean_getFieldIntercept(int fieldIndex) {
+    return null;
+  }
+}

--- a/test/src/test/java/io/ebean/example/MyEntityBean3.java
+++ b/test/src/test/java/io/ebean/example/MyEntityBean3.java
@@ -1,0 +1,154 @@
+package io.ebean.example;
+
+import io.ebean.Model;
+import io.ebean.bean.EntityBean;
+import io.ebean.bean.EntityBeanIntercept;
+import test.model.MyEmbeddedBean;
+
+import javax.persistence.Id;
+
+public class MyEntityBean3 extends Model implements EntityBean {
+
+  EbiInterface intercept;
+
+  @Id
+  Long id;
+
+  MyEmbeddedBean foo;
+  MyEmbeddedBean bar;
+
+  public Object _ebean_newInstanceReadOnly() {
+    return new MyEntityBean3(null);
+  }
+
+  protected MyEntityBean3(EntityBean ignore) {
+    intercept = new EbiReadOnly(this);
+  }
+
+  MyEntityBean3() {
+    intercept = new EbiReadWrite(this);
+  }
+
+  Long getId() {
+    return id;
+  }
+
+  public Long _ebean_get_id() {
+    intercept.preGetId();
+    return id;
+  }
+
+  public void _ebean_set_id(Long newValue) {
+    intercept.preSetter(true, 1, id, newValue);
+    this.id = newValue;
+  }
+
+  @Override
+  public String[] _ebean_getPropertyNames() {
+    return new String[0];
+  }
+
+  @Override
+  public String _ebean_getPropertyName(int pos) {
+    return null;
+  }
+
+  @Override
+  public Object _ebean_newInstance() {
+    return null;
+  }
+
+  @Override
+  public void _ebean_setEmbeddedLoaded() {
+
+  }
+
+  @Override
+  public boolean _ebean_isEmbeddedNewOrDirty() {
+    // for each embedded bean field...
+    if (intercept.isEmbeddedNewOrDirty(foo)) return true;
+    if (intercept.isEmbeddedNewOrDirty(bar)) return true;
+
+    return false;
+ }
+
+  @Override
+  public EntityBeanIntercept _ebean_getIntercept() {
+    return null;
+  }
+
+  @Override
+  public EntityBeanIntercept _ebean_intercept() {
+    return null;
+  }
+
+  @Override
+  public void _ebean_setField(int fieldIndex, Object value) {
+
+    switch (fieldIndex) {
+      case 0:
+        _ebean_set_id((Long)value);
+        break;
+      case 1:
+        _ebean_set_id((Long)value);
+      default:
+        throw new RuntimeException("asd");
+    }
+  }
+
+  Object _ebean_identity;
+
+  public Object _ebean_getIdentity() {
+    synchronized (this) {
+      if (_ebean_identity != null) {
+        return _ebean_identity;
+      }
+
+      Object id = getId();
+      if (id != null) {
+        _ebean_identity = id;
+      } else {
+        _ebean_identity = new Object();
+      }
+
+      return _ebean_identity;
+    }
+  }
+
+  long intId;
+
+  public long getIntId() {
+    return intId;
+  }
+
+  public Object _ebean_getIdentity_primative() {
+    synchronized (this) {
+      if (_ebean_identity != null) {
+        return _ebean_identity;
+      }
+
+      if (getIntId() != 0) {
+        _ebean_identity = Long.valueOf(getIntId());
+      } else {
+        _ebean_identity = new Object();
+      }
+
+      return _ebean_identity;
+    }
+  }
+
+  @Override
+  public void _ebean_setFieldIntercept(int fieldIndex, Object value) {
+
+  }
+
+  @Override
+  public Object _ebean_getField(int fieldIndex) {
+    return null;
+  }
+
+  @Override
+  public Object _ebean_getFieldIntercept(int fieldIndex) {
+    return null;
+  }
+}

--- a/test/src/test/java/io/ebean/example/MyEntityBeanExtends.java
+++ b/test/src/test/java/io/ebean/example/MyEntityBeanExtends.java
@@ -1,0 +1,14 @@
+package io.ebean.example;
+
+import io.ebean.bean.EntityBean;
+
+public class MyEntityBeanExtends extends MyEntityBean2 {
+
+  public Object _ebean_newInstanceReadOnly() {
+    return new MyEntityBeanExtends(null);
+  }
+
+  protected MyEntityBeanExtends(EntityBean ignore) {
+    super(ignore);
+  }
+}

--- a/test/src/test/resources/META-INF/ebean-version.mf
+++ b/test/src/test/resources/META-INF/ebean-version.mf
@@ -1,0 +1,2 @@
+ebean-version: 129
+not-ebean-version: 141


### PR DESCRIPTION
With this change we can support current state which is `EntityBeanIntercept` as a concrete class (`ebean-version: 129`) and we can support a future state where `EntityBeanIntercept` is an interface with 2 implementations - `InterceptReadWrite` and `InterceptReadOnly` `ebean-version: 141`).

This gives Ebean the option to better optimise the case for queries with `readOnly=true` and `disableLazyLoading=true` ... that is, graphs that are built all with eager fetching and typically mapped into DTOs.
