### PR TITLE
Add entity-field-access as experimental option

### DIFF
--- a/ebean-agent/src/main/java/io/ebean/enhance/common/AgentManifest.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/AgentManifest.java
@@ -31,6 +31,7 @@ public class AgentManifest {
   private boolean transientInternalFields;
   private boolean checkNullManyFields = true;
   private boolean enableProfileLocation = true;
+  private boolean enableEntityFieldAccess = true;
   private boolean synthetic = true;
   private int enhancementVersion;
 
@@ -78,6 +79,10 @@ public class AgentManifest {
       + " transactionalPackages:" + transactionalPackages;
   }
 
+  public boolean isDetectEntityBean(String owner) {
+    return detectQueryBean.isEntityBean(owner);
+  }
+
   public boolean isDetectQueryBean(String owner) {
     return detectQueryBean.isQueryBean(owner);
   }
@@ -93,6 +98,9 @@ public class AgentManifest {
     return enableProfileLocation;
   }
 
+  public boolean isEnableEntityFieldAccess() {
+    return enableEntityFieldAccess;
+  }
 
   /**
    * Return the debug level read from ebean.mf
@@ -234,6 +242,10 @@ public class AgentManifest {
     String locationMode = attributes.getValue("profile-location");
     if (locationMode != null) {
       enableProfileLocation = Boolean.parseBoolean(locationMode);
+    }
+    String fieldAccessMode = attributes.getValue("entity-field-access");
+    if (fieldAccessMode != null) {
+      enableEntityFieldAccess = Boolean.parseBoolean(fieldAccessMode);
     }
     String syntheticOption = attributes.getValue("synthetic");
     if (syntheticOption != null) {

--- a/ebean-agent/src/main/java/io/ebean/enhance/common/EnhanceContext.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/EnhanceContext.java
@@ -36,6 +36,7 @@ public class EnhanceContext {
   private final FilterQueryBean filterQueryBean;
   private boolean throwOnError;
   private final boolean enableProfileLocation;
+  private final boolean enableEntityFieldAccess;
   private final int accPublic;
   private final int accProtected;
   private final int accPrivate;
@@ -52,6 +53,7 @@ public class EnhanceContext {
   public EnhanceContext(ClassBytesReader classBytesReader, String agentArgs, AgentManifest manifest, ClassMetaCache metaCache) {
     this.manifest = manifest;
     this.enableProfileLocation = manifest.isEnableProfileLocation();
+    this.enableEntityFieldAccess = manifest.isEnableEntityFieldAccess();
     this.accPublic = manifest.accPublic();
     this.accProtected = manifest.accProtected();
     this.accPrivate = manifest.accPrivate();
@@ -127,6 +129,10 @@ public class EnhanceContext {
     return classBytesReader.getClassBytes(className, classLoader);
   }
 
+  public boolean isEntityBean(String owner) {
+    return manifest.isDetectEntityBean(owner);
+  }
+
   /**
    * Return true if the owner class is a type query bean.
    * <p>
@@ -165,6 +171,10 @@ public class EnhanceContext {
     } else {
       return s.trim().equalsIgnoreCase("true");
     }
+  }
+
+  public boolean isEnableEntityFieldAccess() {
+    return enableEntityFieldAccess;
   }
 
   /**
@@ -370,6 +380,15 @@ public class EnhanceContext {
   public void summaryQueryBeanCaller(String className) {
     if (summaryInfo != null) {
       summaryInfo.addQueryBeanCaller(className);
+    }
+  }
+
+  /**
+   * Add the enhanced class with field access replacement to summary information.
+   */
+  public void summaryFieldAccessUser(String className) {
+    if (summaryInfo != null) {
+      summaryInfo.addFieldAccessUser(className);
     }
   }
 

--- a/ebean-agent/src/main/java/io/ebean/enhance/common/SummaryInfo.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/SummaryInfo.java
@@ -15,6 +15,7 @@ public class SummaryInfo {
   private final Set<String> entities = new HashSet<>();
   private final Set<String> queryBeans = new HashSet<>();
   private final Set<String> queryBeanCallers = new HashSet<>();
+  private final Set<String> fieldAccessUsers = new HashSet<>();
   private final Set<String> transactional = new HashSet<>();
 
   SummaryInfo(List<String> loadedResources) {
@@ -55,6 +56,9 @@ public class SummaryInfo {
     return !queryBeanCallers.isEmpty();
   }
 
+  public boolean hasFieldAccess() {
+    return !fieldAccessUsers.isEmpty();
+  }
 
   public String toString() {
     return " entities:" + entities + " queryBeans:" + queryBeans + " tqb:" + transactional;
@@ -74,6 +78,10 @@ public class SummaryInfo {
 
   void addQueryBeanCaller(String className) {
     queryBeanCallers.add(className);
+  }
+
+  void addFieldAccessUser(String className) {
+    fieldAccessUsers.add(className);
   }
 
   private String summary(String prefix, Set<String> beans) {
@@ -106,6 +114,13 @@ public class SummaryInfo {
    */
   public String queryCallers() {
     return summary("Query Callers", queryBeanCallers);
+  }
+
+  /**
+   * Return a summary of the beans enhanced that call query beans.
+   */
+  public String fieldAccess() {
+    return summary(" Field Access", fieldAccessUsers);
   }
 
   /**

--- a/ebean-agent/src/main/java/io/ebean/enhance/querybean/ClassInfo.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/querybean/ClassInfo.java
@@ -17,14 +17,24 @@ class ClassInfo implements Constants {
   private boolean addedMarkerAnnotation;
   private boolean typeQueryBean;
   private boolean typeQueryUser;
+  private boolean fieldAccessUser;
   private boolean alreadyEnhanced;
   private List<FieldInfo> fields;
   private boolean hasBasicConstructor;
   private boolean hasMainConstructor;
+  private boolean entityBean;
 
   public ClassInfo(EnhanceContext enhanceContext, String className) {
     this.enhanceContext = enhanceContext;
     this.className = className;
+  }
+
+  public void setEntityBean() {
+    entityBean = true;
+  }
+
+  public boolean isEntityBean() {
+    return entityBean;
   }
 
   /**
@@ -69,6 +79,10 @@ class ClassInfo implements Constants {
    */
   boolean isTypeQueryUser() {
     return typeQueryUser;
+  }
+
+  public boolean isFieldAccessUser() {
+    return fieldAccessUser;
   }
 
   /**
@@ -133,6 +147,13 @@ class ClassInfo implements Constants {
       log("change getfield " + owner + " name:" + name);
     }
     typeQueryUser = true;
+  }
+
+  void markEntityFieldAccess(String type, String owner, String name) {
+    if (isLog(2)) {
+      log("replace " + type + " field access " + owner + "." + name);
+    }
+    fieldAccessUser = true;
   }
 
   public boolean isLog(int level) {

--- a/ebean-agent/src/main/java/io/ebean/enhance/querybean/DetectQueryBean.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/querybean/DetectQueryBean.java
@@ -79,6 +79,10 @@ public class DetectQueryBean {
     return false;
   }
 
+  public boolean isEntityBean(String owner) {
+    return isQueryBeanPackage(owner);
+  }
+
   /**
    * Check that the class follows query bean naming convention.
    */

--- a/ebean-agent/src/main/java/io/ebean/enhance/querybean/TypeQueryClassAdapter.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/querybean/TypeQueryClassAdapter.java
@@ -13,6 +13,7 @@ import io.ebean.enhance.common.EnhanceContext;
 import io.ebean.enhance.common.NoEnhancementRequiredException;
 
 import static io.ebean.enhance.Transformer.EBEAN_ASM_VERSION;
+import static io.ebean.enhance.common.EnhanceConstants.C_ENTITYBEAN;
 import static io.ebean.enhance.common.EnhanceConstants.INIT;
 
 /**
@@ -41,6 +42,11 @@ public class TypeQueryClassAdapter extends ClassVisitor implements Constants {
     this.className = name;
     this.signature = signature;
     this.classInfo = new ClassInfo(enhanceContext, name);
+    for (String interfaceType : interfaces) {
+      if (interfaceType.equals(C_ENTITYBEAN)) {
+        classInfo.setEntityBean();
+      }
+    }
   }
 
   /**
@@ -165,12 +171,14 @@ public class TypeQueryClassAdapter extends ClassVisitor implements Constants {
       if (isLog(2)) {
         classInfo.log("enhanced as query bean");
       }
+    } else if (classInfo.isFieldAccessUser()) {
+      enhanceContext.summaryFieldAccessUser(className);
     } else if (classInfo.isTypeQueryUser()) {
       if (isLog(4)) {
         classInfo.log("enhanced - getfield calls replaced");
       }
     } else {
-      throw new NoEnhancementRequiredException("Not a type bean or caller of type beans");
+      throw new NoEnhancementRequiredException("No query bean enhancement");
     }
     super.visitEnd();
   }

--- a/test/src/test/java/io/ebean/enhance/common/SummaryInfoTest.java
+++ b/test/src/test/java/io/ebean/enhance/common/SummaryInfoTest.java
@@ -28,7 +28,9 @@ public class SummaryInfoTest {
 
     assertTrue(summaryInfo.hasQueryBeans());
     assertFalse(summaryInfo.hasQueryCallers());
+    assertFalse(summaryInfo.hasFieldAccess());
     assertEquals("Query Callers (0)  pkgs[] beans[]", summaryInfo.queryCallers());
+    assertEquals(" Field Access (0)  pkgs[] beans[]", summaryInfo.fieldAccess());
   }
 
   @Test
@@ -51,11 +53,13 @@ public class SummaryInfoTest {
     summaryInfo.addQueryBean("org/model/query/QCustomer");
     summaryInfo.addQueryBeanCaller("org/dao/MyDao");
     summaryInfo.addTransactional("org/dao/OtherDao");
+    summaryInfo.addFieldAccessUser("org/model/CustomerTest");
 
     summaryInfo.prepare();
     assertFalse(summaryInfo.isEmpty());
     assertTrue(summaryInfo.hasEntities());
     assertTrue(summaryInfo.hasQueryBeans());
+    assertTrue(summaryInfo.hasFieldAccess());
     assertTrue(summaryInfo.hasQueryCallers());
     assertTrue(summaryInfo.hasTransactional());
 
@@ -63,6 +67,7 @@ public class SummaryInfoTest {
     assertEquals("   QueryBeans (1)  pkgs[org/model/query] beans[QCustomer]", summaryInfo.queryBeans());
     assertEquals("Transactional (1)  pkgs[org/dao] beans[OtherDao]", summaryInfo.transactional());
     assertEquals("Query Callers (1)  pkgs[org/dao] beans[MyDao]", summaryInfo.queryCallers());
+    assertEquals(" Field Access (1)  pkgs[org/model] beans[CustomerTest]", summaryInfo.fieldAccess());
   }
 
   @Test
@@ -74,12 +79,14 @@ public class SummaryInfoTest {
     assertFalse(summaryInfo.hasEntities());
     assertFalse(summaryInfo.hasQueryBeans());
     assertFalse(summaryInfo.hasQueryCallers());
+    assertFalse(summaryInfo.hasFieldAccess());
     assertFalse(summaryInfo.hasTransactional());
 
     assertEquals("     Entities (0)  pkgs[] beans[]", summaryInfo.entities());
     assertEquals("   QueryBeans (0)  pkgs[] beans[]", summaryInfo.queryBeans());
     assertEquals("Transactional (0)  pkgs[] beans[]", summaryInfo.transactional());
     assertEquals("Query Callers (0)  pkgs[] beans[]", summaryInfo.queryCallers());
+    assertEquals(" Field Access (0)  pkgs[] beans[]", summaryInfo.fieldAccess());
   }
 
   @Test


### PR DESCRIPTION
- Entities can use public fields
- Code using GETFIELD/PUTFIELD on entity fields replaced with interceptor get/set methods
- uses entity-packages from manifest to determine if a class is an entity