### PR TITLE
Initial support for Transient collection initialisation in an added default constructor

### DIFF
--- a/ebean-agent/src/main/java/io/ebean/enhance/common/AgentManifest.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/AgentManifest.java
@@ -29,6 +29,7 @@ public class AgentManifest {
   private final DetectQueryBean detectQueryBean;
   private int debugLevel = -1;
   private boolean transientInternalFields;
+  private boolean transientInitMany;
   private boolean checkNullManyFields = true;
   private boolean enableProfileLocation = true;
   private boolean enableEntityFieldAccess;
@@ -128,6 +129,10 @@ public class AgentManifest {
    */
   public boolean isTransactionalNone() {
     return transactionalPackages.contains("none") && transactionalPackages.size() == 1;
+  }
+
+  public boolean isTransientInitMany() {
+    return transientInitMany;
   }
 
   /**
@@ -271,6 +276,7 @@ public class AgentManifest {
   }
 
   private void readOptions(Attributes attributes) {
+    transientInitMany = bool("transient-init-many", transientInitMany, attributes);
     transientInternalFields = bool("transient-internal-fields", transientInternalFields, attributes);
     checkNullManyFields = bool("check-null-many-fields", checkNullManyFields, attributes);
   }

--- a/ebean-agent/src/main/java/io/ebean/enhance/common/EnhanceContext.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/EnhanceContext.java
@@ -308,6 +308,10 @@ public class EnhanceContext {
     return logLevel;
   }
 
+  public boolean isTransientInitMany() {
+    return manifest.isTransientInitMany();
+  }
+
   /**
    * Return true if internal ebean fields in entity classes should be transient.
    */

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/ConstructorAdapter.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/ConstructorAdapter.java
@@ -85,7 +85,7 @@ class ConstructorAdapter extends MethodVisitor implements EnhanceConstants, Opco
 
   @Override
   public void visitFieldInsn(int opcode, String owner, String name, String desc) {
-    if (deferredCode.consumeVisitFieldInsn(opcode, name)) {
+    if (deferredCode.consumeVisitFieldInsn(opcode, owner, name, desc)) {
       // we have removed all the instructions initialising the many property
       return;
     }

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/DefaultConstructor.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/DefaultConstructor.java
@@ -5,6 +5,9 @@ import io.ebean.enhance.asm.Label;
 import io.ebean.enhance.asm.MethodVisitor;
 import io.ebean.enhance.common.ClassMeta;
 
+import java.util.List;
+import java.util.Map;
+
 import static io.ebean.enhance.asm.Opcodes.*;
 import static io.ebean.enhance.common.EnhanceConstants.INIT;
 import static io.ebean.enhance.common.EnhanceConstants.NOARG_VOID;
@@ -32,6 +35,14 @@ class DefaultConstructor {
     mv.visitLineNumber(1, l0);
     mv.visitVarInsn(ALOAD, 0);
     mv.visitMethodInsn(INVOKESPECIAL, classMeta.getSuperClassName(), INIT, NOARG_VOID, false);
+    for (Map.Entry<String, List<DeferredCode>> entry : classMeta.transientInit().entrySet()) {
+      if (classMeta.isLog(2)) {
+        classMeta.log("... default constructor, init transient " + entry.getKey());
+      }
+      for (DeferredCode deferredCode : entry.getValue()) {
+        deferredCode.write(mv);
+      }
+    }
     Label l1 = new Label();
     mv.visitLabel(l1);
     mv.visitLineNumber(2, l1);

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/DeferredCode.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/DeferredCode.java
@@ -6,7 +6,7 @@ import io.ebean.enhance.asm.MethodVisitor;
  * Bytecode instructions that are held/deferred so that they can be removed
  * entirely if desired (initialisation of OneToMany and ManyToMany properties).
  */
-interface DeferredCode {
+public interface DeferredCode {
 
   /**
    * Write the bytecode to the method visitor.

--- a/test/src/test/java/test/model/BeanWithTransientInit.java
+++ b/test/src/test/java/test/model/BeanWithTransientInit.java
@@ -1,0 +1,63 @@
+package test.model;
+
+import javax.persistence.*;
+import java.util.*;
+
+/**
+ * Bean with Transient collections and multiple constructors.
+ */
+@Entity
+public class BeanWithTransientInit {
+
+  @Id
+  private UUID id;
+  private String name;
+  @Transient
+  private final Collection<String> coll1 = new HashSet<>();
+  @Transient
+  private final Map<String, String> coll2;
+  {
+    coll2 = new HashMap<>();
+  }
+  @Transient
+  private final Set<String> coll3;
+
+  public BeanWithTransientInit(UUID id) {
+    this.coll3 = new HashSet<>();
+    this.id = id;
+  }
+
+  public BeanWithTransientInit(String name) {
+    this.coll3 = new TreeSet<>();
+    this.name = name;
+  }
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Collection<String> transientColl1() {
+    return coll1;
+  }
+
+  public Map<String, String> transientColl2() {
+    return coll2;
+  }
+
+  public Set<String> transientColl3() {
+    return coll3;
+  }
+
+}

--- a/test/src/test/java/test/model/BeanWithTransientInitTest.java
+++ b/test/src/test/java/test/model/BeanWithTransientInitTest.java
@@ -1,0 +1,54 @@
+package test.model;
+
+import io.ebean.DB;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.TreeSet;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BeanWithTransientInitTest {
+
+  @Test
+  void testWithInitializer() {
+    UUID id1 = UUID.randomUUID();
+    UUID id2 = UUID.randomUUID();
+
+    BeanWithTransientInit bean1 = new BeanWithTransientInit(id1);
+    bean1.setName("Roland");
+
+    BeanWithTransientInit bean2 = new BeanWithTransientInit("Rob");
+    bean2.setId(id2);
+
+    assertThat(bean1.transientColl1()).isInstanceOf(HashSet.class);
+    assertThat(bean1.transientColl2()).isInstanceOf(HashMap.class);
+    assertThat(bean1.transientColl3()).isInstanceOf(HashSet.class);
+
+    assertThat(bean2.transientColl1()).isInstanceOf(HashSet.class);
+    assertThat(bean2.transientColl2()).isInstanceOf(HashMap.class);
+    assertThat(bean2.transientColl3()).isInstanceOf(TreeSet.class);
+
+    DB.save(bean1);
+    DB.save(bean2);
+
+    bean1 = DB.find(BeanWithTransientInit.class, id1);
+    bean2 = DB.find(BeanWithTransientInit.class, id2);
+
+    // Fetching the bean again, does not trigger the initializers
+    // I also don't think, that this can be handeld by the enhancer
+    // Possible solution: Print warning (or fail) when enhancing.
+
+    assertThat(bean1.getName()).isEqualTo("Roland");
+    assertThat(bean1.transientColl1()).isInstanceOf(HashSet.class);
+    assertThat(bean1.transientColl2()).isInstanceOf(HashMap.class);
+    assertThat(bean1.transientColl3()).isInstanceOf(HashSet.class);
+
+    assertThat(bean2.getName()).isEqualTo("Rob");
+    assertThat(bean2.transientColl1()).isInstanceOf(HashSet.class);
+    assertThat(bean2.transientColl2()).isInstanceOf(HashMap.class);
+    assertThat(bean2.transientColl3()).isInstanceOf(HashSet.class);// HashSet from first constructor wins, not TreeSet.class
+  }
+}

--- a/test/src/test/resources/ebean.mf
+++ b/test/src/test/resources/ebean.mf
@@ -4,3 +4,5 @@ querybean-packages: test.model, foo
 query-labels: true
 debug: 3
 synthetic: false
+transient-init-many: true
+


### PR DESCRIPTION
FYI @rPraml 

What this does not do yet is:
- Handle Transient fields with non-collection types (or TreeSet or TreeMap) - We really want to update to handle any types for `@Transient`
- Detect when initialisation is different across different constructors  (e.g. initialised to HashSet in one constructor and ArrayList in another - we could detect this and log and error saying that it is not handled)
 
My plan is to merge this, then do a tidy up refactor before then looking at those 2 issues.