### PR TITLE
Support transient initialisation in default constructor for other types (non-persistent ones)

### DIFF
--- a/ebean-agent/src/main/java/io/ebean/enhance/common/AgentManifest.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/AgentManifest.java
@@ -30,6 +30,7 @@ public final class AgentManifest {
   private int debugLevel = -1;
   private boolean transientInternalFields;
   private boolean transientInit;
+  private boolean transientInitThrowError;
   private boolean checkNullManyFields = true;
   private boolean enableProfileLocation = true;
   private boolean enableEntityFieldAccess;
@@ -131,8 +132,18 @@ public final class AgentManifest {
     return transactionalPackages.contains("none") && transactionalPackages.size() == 1;
   }
 
+  /**
+   * Return true if enhancement should add initialisation of transient fields when adding a default constructor.
+   */
   public boolean isTransientInit() {
     return transientInit;
+  }
+
+  /**
+   * Return true if an error should be thrown when adding a default constructor and transient fields can't be initialised.
+   */
+  public boolean isTransientInitThrowError() {
+    return transientInitThrowError;
   }
 
   /**
@@ -277,6 +288,7 @@ public final class AgentManifest {
 
   private void readOptions(Attributes attributes) {
     transientInit = bool("transient-init", transientInit, attributes);
+    transientInitThrowError = bool("transient-init-error", transientInit, attributes);
     transientInternalFields = bool("transient-internal-fields", transientInternalFields, attributes);
     checkNullManyFields = bool("check-null-many-fields", checkNullManyFields, attributes);
   }

--- a/ebean-agent/src/main/java/io/ebean/enhance/common/AgentManifest.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/AgentManifest.java
@@ -29,7 +29,7 @@ public final class AgentManifest {
   private final DetectQueryBean detectQueryBean;
   private int debugLevel = -1;
   private boolean transientInternalFields;
-  private boolean transientInitMany;
+  private boolean transientInit;
   private boolean checkNullManyFields = true;
   private boolean enableProfileLocation = true;
   private boolean enableEntityFieldAccess;
@@ -131,8 +131,8 @@ public final class AgentManifest {
     return transactionalPackages.contains("none") && transactionalPackages.size() == 1;
   }
 
-  public boolean isTransientInitMany() {
-    return transientInitMany;
+  public boolean isTransientInit() {
+    return transientInit;
   }
 
   /**
@@ -276,7 +276,7 @@ public final class AgentManifest {
   }
 
   private void readOptions(Attributes attributes) {
-    transientInitMany = bool("transient-init-many", transientInitMany, attributes);
+    transientInit = bool("transient-init", transientInit, attributes);
     transientInternalFields = bool("transient-internal-fields", transientInternalFields, attributes);
     checkNullManyFields = bool("check-null-many-fields", checkNullManyFields, attributes);
   }

--- a/ebean-agent/src/main/java/io/ebean/enhance/common/ClassMeta.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/ClassMeta.java
@@ -43,6 +43,14 @@ public class ClassMeta {
   private boolean hasDefaultConstructor;
   private boolean hasStaticInit;
 
+  /**
+   * If enhancement is adding a default constructor - only single type is supported initialising transient fields.
+   */
+  private final Set<String> unsupportedTransientMultipleTypes = new LinkedHashSet<>();
+  /**
+   * If enhancement is adding a default constructor - only default constructors are supported initialising transient fields.
+   */
+  private final Set<String> unsupportedTransientInitialisation = new LinkedHashSet<>();
   private final Map<String, CapturedInitCode> transientInitCode = new LinkedHashMap<>();
   private final LinkedHashMap<String, FieldMeta> fields = new LinkedHashMap<>();
   private final HashSet<String> classAnnotation = new HashSet<>();
@@ -188,12 +196,16 @@ public class ClassMeta {
     return (f != null) && f.isPersistent();
   }
 
+  public boolean isTransient(String fieldName) {
+    FieldMeta f = field(fieldName);
+    return (f != null && f.isTransient());
+  }
+
   public boolean isInitTransient(String fieldName) {
     if (!enhanceContext.isTransientInit()) {
       return false;
     }
-    FieldMeta f = field(fieldName);
-    return (f != null && f.isTransient());
+    return isTransient(fieldName);
   }
 
   /**
@@ -416,14 +428,32 @@ public class ClassMeta {
     CapturedInitCode old = transientInitCode.put(deferredInitCode.name(), deferredInitCode);
     if (old != null && !old.type().equals(deferredInitCode.type())) {
       transientInitCode.put(deferredInitCode.name(), old);
-      String msg = "ERROR: Transient field " + old.name() + " initialised in constructor with 2 different types " + old.mismatch(deferredInitCode.type()) + ", this is not supported ";
-      log(msg);
-      System.err.println(msg);
+      unsupportedTransientMultipleTypes.add("field: " + old.name() + " types: " + old.type() + " " + deferredInitCode.type());
     }
   }
 
   public Collection<CapturedInitCode> transientInit() {
     return transientInitCode.values();
+  }
+
+  public void addUnsupportedTransientInit(String name) {
+    unsupportedTransientInitialisation.add(name);
+  }
+
+  public boolean hasTransientFieldErrors() {
+    return !unsupportedTransientMultipleTypes.isEmpty() || !unsupportedTransientInitialisation.isEmpty();
+  }
+
+  public String transientFieldErrorMessage() {
+    String msg = "ERROR: Entity class without default constructor has unsupported initialisation of transient fields. Entity class: " + className;
+    if (!unsupportedTransientMultipleTypes.isEmpty()) {
+      msg += " - fields initialised in constructor with 2 different types - " + unsupportedTransientMultipleTypes;
+    }
+    if (!unsupportedTransientInitialisation.isEmpty()) {
+      msg += " - Unsupported initialisation of transient fields - " + unsupportedTransientInitialisation;
+    }
+    msg += " Refer: https://ebean.io/docs/trouble-shooting#transient-initialisation";
+    return msg;
   }
 
   private static final class MethodReader extends MethodVisitor {

--- a/ebean-agent/src/main/java/io/ebean/enhance/common/EnhanceContext.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/EnhanceContext.java
@@ -314,6 +314,10 @@ public final class EnhanceContext {
     return manifest.isTransientInit();
   }
 
+  public boolean isTransientInitThrowError() {
+    return manifest.isTransientInitThrowError();
+  }
+
   /**
    * Return true if internal ebean fields in entity classes should be transient.
    */

--- a/ebean-agent/src/main/java/io/ebean/enhance/common/EnhanceContext.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/EnhanceContext.java
@@ -310,8 +310,8 @@ public final class EnhanceContext {
     return logLevel;
   }
 
-  public boolean isTransientInitMany() {
-    return manifest.isTransientInitMany();
+  public boolean isTransientInit() {
+    return manifest.isTransientInit();
   }
 
   /**

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/CapturedInitCode.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/CapturedInitCode.java
@@ -1,0 +1,70 @@
+package io.ebean.enhance.entity;
+
+import io.ebean.enhance.asm.MethodVisitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Code that initialises a transient field.
+ * <p>
+ * Added into a default constructor when that is added to an entity bean.
+ */
+public final class CapturedInitCode {
+
+  private final String name;
+  private final String type;
+  private final List<DeferredCode> code;
+
+  CapturedInitCode(List<DeferredCode> codes, int opcode, String owner, String name, String desc, String type) {
+    this.name = name;
+    this.type = type;
+    this.code = new ArrayList<>(codes);
+    this.code.add(new PutField(opcode, owner, name, desc));
+  }
+
+  /**
+   * Return the field name.
+   */
+  public String name() {
+    return name;
+  }
+
+  /**
+   * Return the concrete type the field is initialised to.
+   */
+  public String type() {
+    return type;
+  }
+
+  /**
+   * Write the code that initialises the field.
+   */
+  public void write(ConstructorAdapter mv) {
+    for (DeferredCode deferredCode : code) {
+      deferredCode.write(mv);
+    }
+  }
+
+  public String mismatch(String type2) {
+    return "type1:" + type + " type2:" + type2;
+  }
+
+  private static class PutField implements DeferredCode {
+    final int opcode;
+    final String owner, name, desc;
+
+    public PutField(int opcode, String owner, String name, String desc) {
+      this.opcode = opcode;
+      this.owner = owner;
+      this.name = name;
+      this.desc = desc;
+    }
+
+    @Override
+    public void write(MethodVisitor mv) {
+      mv.visitFieldInsn(opcode, owner, name, desc);
+    }
+  }
+
+}

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/ConstructorDeferredCode.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/ConstructorDeferredCode.java
@@ -55,6 +55,7 @@ final class ConstructorDeferredCode implements Opcodes {
   private final MethodVisitor mv;
   private final List<DeferredCode> codes = new ArrayList<>();
   private State state = State.UNSET;
+  private String stateInitialiseType;
 
   ConstructorDeferredCode(ClassMeta meta, MethodVisitor mv) {
     this.meta = meta;
@@ -84,7 +85,7 @@ final class ConstructorDeferredCode implements Opcodes {
    * and was proceeded by a deferred ALOAD (for NEW) or Collection init (for CHECKCAST).
    */
   boolean deferVisitTypeInsn(int opcode, String type) {
-    if (opcode == NEW && stateAload() && isCollection(type)) {
+    if (opcode == NEW && stateAload()) { // && isCollection(type)) {
       codes.add(new NewCollection(type));
       state = State.NEW_COLLECTION;
       return true;
@@ -122,20 +123,18 @@ final class ConstructorDeferredCode implements Opcodes {
    * and was proceeded by a deferred DUP.
    */
   boolean deferVisitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
-    if (opcode == INVOKESPECIAL && stateDup() && isCollectionInit(owner, name, desc)) {
-      codes.add(new CollectionInit(opcode, owner, name, desc, itf));
+    if (opcode == INVOKESPECIAL && stateDup() && isNoArgInit(name, desc)) {
+      codes.add(new NoArgInit(opcode, owner, name, desc, itf));
       state = State.INVOKE_SPECIAL;
+      stateInitialiseType = owner;
       return true;
     }
     flush();
     return false;
   }
 
-  /**
-   * Return true if this is an init of a ArrayList, HashSet, LinkedHashSet.
-   */
-  private boolean isCollectionInit(String owner, String name, String desc) {
-    return name.equals(INIT) && desc.equals(NOARG_VOID) && isCollection(owner);
+  private boolean isNoArgInit(String name, String desc) {
+    return name.equals(INIT) && desc.equals(NOARG_VOID);
   }
 
   /**
@@ -143,22 +142,20 @@ final class ConstructorDeferredCode implements Opcodes {
    */
   boolean consumeVisitFieldInsn(int opcode, String owner, String name, String desc) {
     if (opcode == PUTFIELD && stateConsumeDeferred()) {
-      if (meta.isConsumeInitMany(name)) {
+      if (meta.isConsumeInitMany(name) && isConsumeManyType()) {
         if (meta.isLog(3)) {
           meta.log("... consumed init of many: " + name);
         }
         state = State.UNSET;
         codes.clear();
         return true;
-      } else if (meta.isInitTransientMany(name)) {
-        // keep the initialisation code for transient collection to
-        // 'replay' it when adding a default constructor if needed
+      } else if (meta.isInitTransient(name)) {
+        // keep the initialisation code for transient to 'replay'
+        // it when adding a default constructor if needed
         if (meta.isLog(3)) {
-          meta.log("... init transient many: " + name);
+          meta.log("... init transient: " + name + " type: " + stateInitialiseType);
         }
-        List<DeferredCode> copy = new ArrayList<>(codes);
-        copy.add(new PutField(opcode, owner, name, desc));
-        meta.addTransientInit(name, copy);
+        meta.addTransientInit(new CapturedInitCode(codes, opcode, owner, name, desc, stateInitialiseType));
       }
     }
     flush();
@@ -220,31 +217,14 @@ final class ConstructorDeferredCode implements Opcodes {
   }
 
   /**
-   * Return true if this is a collection type used to initialise persistent collections.
+   * Return true if the type being initialised is valid for auto initialisation of ToMany or DbArray.
    */
-  private boolean isCollection(String type) {
-    return ("java/util/ArrayList".equals(type)
-      || "java/util/LinkedHashSet".equals(type)
-      // || "java/util/TreeSet".equals(type)
-      || "java/util/HashSet".equals(type)
-      || "java/util/LinkedHashMap".equals(type)
-      // || "java/util/TreeMap".equals(type)
-      || "java/util/HashMap".equals(type));
-  }
-
-  private static class PutField implements DeferredCode {
-    final int opcode;
-    final String owner,name, desc;
-    public PutField(int opcode, String owner, String name, String desc) {
-      this.opcode = opcode;
-      this.owner = owner;
-      this.name = name;
-      this.desc = desc;
-    }
-    @Override
-    public void write(MethodVisitor mv) {
-      mv.visitFieldInsn(opcode, owner, name, desc);
-    }
+  private boolean isConsumeManyType() {
+    return ("java/util/ArrayList".equals(stateInitialiseType)
+      || "java/util/LinkedHashSet".equals(stateInitialiseType)
+      || "java/util/HashSet".equals(stateInitialiseType));
+      //|| "java/util/LinkedHashMap".equals(stateInitialiseType)
+      //|| "java/util/HashMap".equals(stateInitialiseType));
   }
 
   private static class ALoad implements DeferredCode {
@@ -342,7 +322,7 @@ final class ConstructorDeferredCode implements Opcodes {
   /**
    * Typically INVOKESPECIAL java/util/ArrayList.<init> ()V
    */
-  private static class CollectionInit implements DeferredCode {
+  private static class NoArgInit implements DeferredCode {
 
     final int opcode;
     final String owner;
@@ -350,7 +330,7 @@ final class ConstructorDeferredCode implements Opcodes {
     final String desc;
     final boolean itf;
 
-    CollectionInit(int opcode, String owner, String name, String desc, boolean itf) {
+    NoArgInit(int opcode, String owner, String name, String desc, boolean itf) {
       this.opcode = opcode;
       this.owner = owner;
       this.name = name;

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/DefaultConstructor.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/DefaultConstructor.java
@@ -21,6 +21,14 @@ class DefaultConstructor {
     if (classMeta.isLog(4)) {
       classMeta.log("... adding default constructor, super class: " + classMeta.superClassName());
     }
+    if (classMeta.hasTransientFieldErrors()) {
+      if (classMeta.context().isTransientInitThrowError()) {
+        throw new RuntimeException(classMeta.transientFieldErrorMessage());
+      } else {
+        // the default constructor being added will leave some transient fields uninitialised (null, 0, false etc)
+        System.err.println(classMeta.transientFieldErrorMessage());
+      }
+    }
 
     MethodVisitor underlyingMV = cw.visitMethod(classMeta.accPublic(), INIT, NOARG_VOID, null, null);
 

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/DefaultConstructor.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/DefaultConstructor.java
@@ -5,9 +5,6 @@ import io.ebean.enhance.asm.Label;
 import io.ebean.enhance.asm.MethodVisitor;
 import io.ebean.enhance.common.ClassMeta;
 
-import java.util.List;
-import java.util.Map;
-
 import static io.ebean.enhance.asm.Opcodes.*;
 import static io.ebean.enhance.common.EnhanceConstants.INIT;
 import static io.ebean.enhance.common.EnhanceConstants.NOARG_VOID;
@@ -35,13 +32,11 @@ class DefaultConstructor {
     mv.visitLineNumber(1, l0);
     mv.visitVarInsn(ALOAD, 0);
     mv.visitMethodInsn(INVOKESPECIAL, classMeta.superClassName(), INIT, NOARG_VOID, false);
-    for (Map.Entry<String, List<DeferredCode>> entry : classMeta.transientInit().entrySet()) {
+    for (CapturedInitCode entry : classMeta.transientInit()) {
       if (classMeta.isLog(2)) {
-        classMeta.log("... default constructor, init transient " + entry.getKey());
+        classMeta.log("... default constructor, init transient " + entry.name() + " type: " + entry.type());
       }
-      for (DeferredCode deferredCode : entry.getValue()) {
-        deferredCode.write(mv);
-      }
+      entry.write(mv);
     }
     Label l1 = new Label();
     mv.visitLabel(l1);

--- a/test/src/test/java/test/model/BeanWithInvalidTransientInit.java
+++ b/test/src/test/java/test/model/BeanWithInvalidTransientInit.java
@@ -1,0 +1,77 @@
+package test.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Transient;
+import java.util.*;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Bean with Transient collections and multiple constructors.
+ */
+@Entity
+public class BeanWithInvalidTransientInit {
+
+  @Id
+  private UUID id;
+  private String name;
+  @Transient
+  private final Collection<String> transientSimpleCollection = new HashSet<>();
+  @Transient
+  private final Lock lock = new ReentrantLock();
+
+  /**
+   * Unsupported, as NOT using default constructor for HashMap.
+   */
+  @Transient
+  private final Map<String, String> invalidTransientInitWithoutDefaultConstructor = new HashMap<>(16);
+
+  /**
+   * Unsupported, as using method to initialise.
+   */
+  @Transient
+  private Set<String> invalidTransientInitViaMethod;
+
+  public BeanWithInvalidTransientInit(UUID id) {
+    this.id = id;
+    this.invalidTransientInitViaMethod = initialiseViaMethod();
+  }
+
+  private Set<String> initialiseViaMethod() {
+    return new HashSet<>();
+  }
+
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Collection<String> transientColl1() {
+    return transientSimpleCollection;
+  }
+
+  public Map<String, String> invalidTransientInitWithoutDefaultConstructor() {
+    return invalidTransientInitWithoutDefaultConstructor;
+  }
+
+  public Set<String> invalidTransientInitViaMethod() {
+    return invalidTransientInitViaMethod;
+  }
+
+  public Lock transientLock() {
+    return lock;
+  }
+}

--- a/test/src/test/java/test/model/BeanWithInvalidTransientInitTest.java
+++ b/test/src/test/java/test/model/BeanWithInvalidTransientInitTest.java
@@ -1,0 +1,40 @@
+package test.model;
+
+import io.ebean.DB;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BeanWithInvalidTransientInitTest {
+
+  @Test
+  void testWithInitializer() {
+    UUID id1 = UUID.randomUUID();
+
+    BeanWithInvalidTransientInit bean1 = new BeanWithInvalidTransientInit(id1);
+    bean1.setName("Foo");
+
+    assertThat(bean1.transientColl1()).isInstanceOf(HashSet.class);
+    assertThat(bean1.transientLock()).isInstanceOf(ReentrantLock.class);
+    assertThat(bean1.invalidTransientInitViaMethod()).isInstanceOf(HashSet.class);
+    assertThat(bean1.invalidTransientInitWithoutDefaultConstructor()).isInstanceOf(HashMap.class);
+
+    DB.save(bean1);
+
+    bean1 = DB.find(BeanWithInvalidTransientInit.class, id1);
+
+    assertThat(bean1.getName()).isEqualTo("Foo");
+    assertThat(bean1.transientColl1()).isInstanceOf(HashSet.class);
+    assertThat(bean1.transientLock()).isInstanceOf(ReentrantLock.class);
+
+    // these are null as when ebean adds the default constructor it is
+    // not adding code to initialise these transient fields
+    assertThat(bean1.invalidTransientInitViaMethod()).isNull();
+    assertThat(bean1.invalidTransientInitWithoutDefaultConstructor()).isNull();
+  }
+}

--- a/test/src/test/java/test/model/BeanWithTransientInit.java
+++ b/test/src/test/java/test/model/BeanWithTransientInit.java
@@ -2,6 +2,8 @@ package test.model;
 
 import javax.persistence.*;
 import java.util.*;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Bean with Transient collections and multiple constructors.
@@ -21,6 +23,18 @@ public class BeanWithTransientInit {
   }
   @Transient
   private final Set<String> coll3;
+
+  /**
+   * Check transient initialisation of non persistence collection type.
+   */
+  @Transient
+  private final Set<String> coll4 = new TreeSet<>();
+
+  /**
+   * Check transient initialisation of non collection type.
+   */
+  @Transient
+  private final Lock lock = new ReentrantLock();
 
   public BeanWithTransientInit(UUID id) {
     this.coll3 = new HashSet<>();
@@ -60,4 +74,11 @@ public class BeanWithTransientInit {
     return coll3;
   }
 
+  public Set<String> transientColl4() {
+    return coll4;
+  }
+
+  public Lock transientLock() {
+    return lock;
+  }
 }

--- a/test/src/test/java/test/model/BeanWithTransientInitDC.java
+++ b/test/src/test/java/test/model/BeanWithTransientInitDC.java
@@ -1,0 +1,92 @@
+package test.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Transient;
+import java.util.*;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Bean with default constructor - all transient initialisation is under developer control.
+ */
+@Entity
+public class BeanWithTransientInitDC {
+
+  @Id
+  private UUID id;
+  private String name;
+  @Transient
+  private final Collection<String> transientSimpleCollection = new HashSet<>();
+  @Transient
+  private final Lock lock = new ReentrantLock();
+
+  /**
+   * Unsupported, as NOT using default constructor for HashMap.
+   */
+  @Transient
+  private final Collection<String> transientInitWithoutDefaultConstructor;
+
+  /**
+   * Unsupported, as using method to initialise.
+   */
+  @Transient
+  private Set<String> transientInitViaMethod;
+
+  /**
+   * Developer specified Default constructor - so ALL transient initialisation is under developer control.
+   */
+  public BeanWithTransientInitDC() {
+    this.transientInitViaMethod = initialiseViaMethod();
+    this.transientInitWithoutDefaultConstructor = new LinkedHashSet<>(40);
+  }
+
+  public BeanWithTransientInitDC(UUID id) {
+    this.id = id;
+    this.transientInitViaMethod = initialiseViaMethod();
+    this.transientInitWithoutDefaultConstructor = new ArrayList<>(40);
+  }
+
+  public BeanWithTransientInitDC(String name) {
+    this.name = name;
+    this.transientInitViaMethod = initialiseViaMethod();
+    this.transientInitWithoutDefaultConstructor = new HashSet<>(16);
+  }
+
+  private Set<String> initialiseViaMethod() {
+    return new HashSet<>();
+  }
+
+
+  public UUID getId() {
+    return id;
+  }
+
+  public void setId(UUID id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Collection<String> transientColl1() {
+    return transientSimpleCollection;
+  }
+
+  public Collection<String> transientInitWithoutDefaultConstructor() {
+    return transientInitWithoutDefaultConstructor;
+  }
+
+  public Set<String> transientInitViaMethod() {
+    return transientInitViaMethod;
+  }
+
+  public Lock transientLock() {
+    return lock;
+  }
+}

--- a/test/src/test/java/test/model/BeanWithTransientInitDCTest.java
+++ b/test/src/test/java/test/model/BeanWithTransientInitDCTest.java
@@ -1,0 +1,59 @@
+package test.model;
+
+import io.ebean.DB;
+import org.junit.jupiter.api.Test;
+
+import java.util.*;
+import java.util.concurrent.locks.ReentrantLock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BeanWithTransientInitDCTest {
+
+  @Test
+  void testWithInitializer() {
+    UUID id1 = UUID.randomUUID();
+    UUID id2 = UUID.randomUUID();
+
+    BeanWithTransientInitDC bean1 = new BeanWithTransientInitDC(id1);
+    bean1.setName("Foo");
+    BeanWithTransientInitDC bean2 = new BeanWithTransientInitDC("Bar");
+    bean2.setId(id2);
+
+    assertThat(bean1.transientColl1()).isInstanceOf(HashSet.class);
+    assertThat(bean1.transientLock()).isInstanceOf(ReentrantLock.class);
+    assertThat(bean1.transientInitViaMethod()).isInstanceOf(HashSet.class);
+    assertThat(bean1.transientInitWithoutDefaultConstructor()).isInstanceOf(ArrayList.class);
+
+    assertThat(bean2.transientColl1()).isInstanceOf(HashSet.class);
+    assertThat(bean2.transientLock()).isInstanceOf(ReentrantLock.class);
+    assertThat(bean2.transientInitViaMethod()).isInstanceOf(HashSet.class);
+    assertThat(bean2.transientInitWithoutDefaultConstructor()).isInstanceOf(HashSet.class);
+
+    DB.save(bean1);
+    DB.save(bean2);
+
+    {
+      bean1 = DB.find(BeanWithTransientInitDC.class, id1);
+
+      assertThat(bean1.getName()).isEqualTo("Foo");
+      assertThat(bean1.transientColl1()).isInstanceOf(HashSet.class);
+      assertThat(bean1.transientLock()).isInstanceOf(ReentrantLock.class);
+
+      // Developer added the default constructor so these are still all as expected
+      assertThat(bean1.transientInitViaMethod()).isInstanceOf(HashSet.class);
+      assertThat(bean1.transientInitWithoutDefaultConstructor()).isInstanceOf(LinkedHashSet.class);
+    }
+    {
+      bean2 = DB.find(BeanWithTransientInitDC.class, id2);
+
+      assertThat(bean2.getName()).isEqualTo("Bar");
+      assertThat(bean2.transientColl1()).isInstanceOf(HashSet.class);
+      assertThat(bean2.transientLock()).isInstanceOf(ReentrantLock.class);
+
+      // Developer added the default constructor so these are still all as expected
+      assertThat(bean2.transientInitViaMethod()).isInstanceOf(HashSet.class);
+      assertThat(bean2.transientInitWithoutDefaultConstructor()).isInstanceOf(LinkedHashSet.class);
+    }
+  }
+}

--- a/test/src/test/java/test/model/BeanWithTransientInitTest.java
+++ b/test/src/test/java/test/model/BeanWithTransientInitTest.java
@@ -42,9 +42,6 @@ class BeanWithTransientInitTest {
     bean1 = DB.find(BeanWithTransientInit.class, id1);
     bean2 = DB.find(BeanWithTransientInit.class, id2);
 
-    // Fetching the bean again, does not trigger the initializers
-    // I also don't think, that this can be handeld by the enhancer
-    // Possible solution: Print warning (or fail) when enhancing.
 
     assertThat(bean1.getName()).isEqualTo("Roland");
     assertThat(bean1.transientColl1()).isInstanceOf(HashSet.class);

--- a/test/src/test/java/test/model/BeanWithTransientInitTest.java
+++ b/test/src/test/java/test/model/BeanWithTransientInitTest.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.TreeSet;
 import java.util.UUID;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,10 +27,14 @@ class BeanWithTransientInitTest {
     assertThat(bean1.transientColl1()).isInstanceOf(HashSet.class);
     assertThat(bean1.transientColl2()).isInstanceOf(HashMap.class);
     assertThat(bean1.transientColl3()).isInstanceOf(HashSet.class);
+    assertThat(bean1.transientColl4()).isInstanceOf(TreeSet.class);
+    assertThat(bean1.transientLock()).isInstanceOf(ReentrantLock.class);
 
     assertThat(bean2.transientColl1()).isInstanceOf(HashSet.class);
     assertThat(bean2.transientColl2()).isInstanceOf(HashMap.class);
     assertThat(bean2.transientColl3()).isInstanceOf(TreeSet.class);
+    assertThat(bean2.transientColl4()).isInstanceOf(TreeSet.class);
+    assertThat(bean2.transientLock()).isInstanceOf(ReentrantLock.class);
 
     DB.save(bean1);
     DB.save(bean2);
@@ -45,10 +50,14 @@ class BeanWithTransientInitTest {
     assertThat(bean1.transientColl1()).isInstanceOf(HashSet.class);
     assertThat(bean1.transientColl2()).isInstanceOf(HashMap.class);
     assertThat(bean1.transientColl3()).isInstanceOf(HashSet.class);
+    assertThat(bean1.transientColl4()).isInstanceOf(TreeSet.class);
+    assertThat(bean1.transientLock()).isInstanceOf(ReentrantLock.class);
 
     assertThat(bean2.getName()).isEqualTo("Rob");
     assertThat(bean2.transientColl1()).isInstanceOf(HashSet.class);
     assertThat(bean2.transientColl2()).isInstanceOf(HashMap.class);
     assertThat(bean2.transientColl3()).isInstanceOf(HashSet.class);// HashSet from first constructor wins, not TreeSet.class
+    assertThat(bean2.transientColl4()).isInstanceOf(TreeSet.class);
+    assertThat(bean2.transientLock()).isInstanceOf(ReentrantLock.class);
   }
 }

--- a/test/src/test/resources/ebean.mf
+++ b/test/src/test/resources/ebean.mf
@@ -4,5 +4,5 @@ querybean-packages: test.model, foo
 query-labels: true
 debug: 3
 synthetic: false
-transient-init-many: true
+transient-init: true
 

--- a/test/src/test/resources/ebean.mf
+++ b/test/src/test/resources/ebean.mf
@@ -5,4 +5,5 @@ query-labels: true
 debug: 3
 synthetic: false
 transient-init: true
+transient-init-error: false
 


### PR DESCRIPTION
The code that captures initialisation code was originally designed to capture and consume initialisation of OneToMany and ManyToMany (thus ArrayList, LinkedHashSet, HashSet types).

This change defers the check of the type being initialised for the OneToMany,ManyToMany,DbArray cases and thus allows the use of this capturing for transient fields being initialised. We want this when we have entity classes without default constructors ... and for this case when ebean enhancement adds the default constructor we want to also add in code that initialises the transient fields by replaying the code captured when visiting the constructor(s).

Note that this also detects the case that ebean enhancement can not handle which is when a transient field is initialised to different types in different constructors - e.g. initialised to a TreeSet in one constructor and an ArrayList in another constructor. When the enhancement detects this it logs an error to sysout ... and when creating the default constructor will use the type from the first constructor it visits.


FYI @rPraml 