### PR TITLE
Add allowNullableDbArray - effectively a bug fix where currently DbArray are automatically initialised

### DIFF
--- a/ebean-agent/src/main/java/io/ebean/enhance/common/AgentManifest.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/AgentManifest.java
@@ -28,6 +28,7 @@ public final class AgentManifest {
   private final Set<String> querybeanPackages = new HashSet<>();
   private final DetectQueryBean detectQueryBean;
   private int debugLevel = -1;
+  private boolean allowNullableDbArray;
   private boolean transientInternalFields;
   private boolean transientInit;
   private boolean transientInitThrowError;
@@ -158,6 +159,10 @@ public final class AgentManifest {
    */
   public boolean isCheckNullManyFields() {
     return checkNullManyFields;
+  }
+
+  public boolean isAllowNullableDbArray() {
+    return allowNullableDbArray;
   }
 
   public int accPublic() {
@@ -291,6 +296,7 @@ public final class AgentManifest {
     transientInitThrowError = bool("transient-init-error", transientInit, attributes);
     transientInternalFields = bool("transient-internal-fields", transientInternalFields, attributes);
     checkNullManyFields = bool("check-null-many-fields", checkNullManyFields, attributes);
+    allowNullableDbArray = bool("allow-nullable-dbarray", allowNullableDbArray, attributes);
   }
 
   private boolean bool(String key, boolean defaultValue, Attributes attributes) {

--- a/ebean-agent/src/main/java/io/ebean/enhance/common/ClassMeta.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/ClassMeta.java
@@ -81,6 +81,10 @@ public class ClassMeta {
     return annotationInfo;
   }
 
+  public boolean isAllowNullableDbArray() {
+    return enhanceContext.isAllowNullableDbArray();
+  }
+
   /**
    * Return the transactional annotation information for a matching interface method.
    */

--- a/ebean-agent/src/main/java/io/ebean/enhance/common/EnhanceConstants.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/EnhanceConstants.java
@@ -53,4 +53,6 @@ public interface EnhanceConstants {
   String LINKEDHASHMAP = "java/util/LinkedHashMap";
   String L_JETBRAINS_NOTNULL = "Lorg/jetbrains/annotations/NotNull;";
   String L_EBEAN_NOTNULL = "Lio/ebean/annotation/NotNull;";
+  String L_COLUMN_ANNOTATION = "Ljavax/persistence/Column;";
+  String L_DBARRAY = "Lio/ebean/annotation/DbArray;";
 }

--- a/ebean-agent/src/main/java/io/ebean/enhance/common/EnhanceContext.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/common/EnhanceContext.java
@@ -335,6 +335,10 @@ public final class EnhanceContext {
     return manifest.isCheckNullManyFields();
   }
 
+  public boolean isAllowNullableDbArray() {
+    return manifest.isAllowNullableDbArray();
+  }
+
   /**
    * Return true if transform should throw exception rather than log and return null.
    */

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/FieldAnnotationVisitor.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/FieldAnnotationVisitor.java
@@ -1,0 +1,23 @@
+package io.ebean.enhance.entity;
+
+import io.ebean.enhance.asm.AnnotationVisitor;
+
+import static io.ebean.enhance.Transformer.EBEAN_ASM_VERSION;
+
+final class FieldAnnotationVisitor extends AnnotationVisitor {
+
+  private final FieldMeta fieldMeta;
+
+  FieldAnnotationVisitor(FieldMeta fieldMeta, AnnotationVisitor visitor) {
+    super(EBEAN_ASM_VERSION, visitor);
+    this.fieldMeta = fieldMeta;
+  }
+
+  @Override
+  public void visit(String name, Object value) {
+    super.visit(name, value);
+    if ("nullable".equals(name) && "false".equals(String.valueOf(value))) {
+      fieldMeta.setNotNull();
+    }
+  }
+}

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/FieldMeta.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/FieldMeta.java
@@ -35,12 +35,12 @@ public final class FieldMeta implements Opcodes, EnhanceConstants, Comparable<Fi
 
   private int indexPosition;
   private int sortOrder;
+  private boolean notNull;
 
   /**
    * Construct based on field name and desc from reading byte code.
    * <p>
    * Used for reading local fields (not inherited) via visiting the class bytes.
-   * </p>
    */
   public FieldMeta(ClassMeta classMeta, String name, String desc, String fieldClass) {
     this.classMeta = classMeta;
@@ -113,11 +113,22 @@ public final class FieldMeta implements Opcodes, EnhanceConstants, Comparable<Fi
     return primitiveType;
   }
 
+  public void setNotNull() {
+    this.notNull = true;
+  }
+
+  public boolean isNullable() {
+    return !notNull;
+  }
+
   /**
    * Add a field annotation.
    */
   void addAnnotationDesc(String desc) {
     annotations.add(desc);
+    if (!notNull && desc.equals(L_EBEAN_NOTNULL)) {
+      notNull = true;
+    }
   }
 
   /**
@@ -201,7 +212,11 @@ public final class FieldMeta implements Opcodes, EnhanceConstants, Comparable<Fi
    * This means these properties are lazy initialised on demand.
    */
   public boolean isInitMany() {
-    return isToMany() || isDbArray();
+    return isToMany() || isInitDbArray();
+  }
+
+  private boolean isInitDbArray() {
+    return isDbArray() && (notNull || !classMeta.isAllowNullableDbArray());
   }
 
   private boolean isDbArray() {

--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/LocalFieldVisitor.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/LocalFieldVisitor.java
@@ -38,11 +38,20 @@ public class LocalFieldVisitor extends FieldVisitor implements EnhanceConstants 
     if (fv != null) {
       if (!visible && desc.equals(L_JETBRAINS_NOTNULL)) {
         fv.visitAnnotation(L_EBEAN_NOTNULL, true);
+        fieldMeta.setNotNull();
+      }
+      if (fieldMeta.isNullable() && annotationWithNullable(desc)) {
+        // looking for nullable=false attribute on Column or DbArray
+        return new FieldAnnotationVisitor(fieldMeta, fv.visitAnnotation(desc, visible));
       }
       return fv.visitAnnotation(desc, visible);
     } else {
       return null;
     }
+  }
+
+  private boolean annotationWithNullable(String desc) {
+    return L_COLUMN_ANNOTATION.equals(desc) || L_DBARRAY.equals(desc);
   }
 
   @Override

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -37,6 +37,13 @@
 
     <dependency>
       <groupId>io.ebean</groupId>
+      <artifactId>ebean-annotation</artifactId>
+      <version>8.3</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.ebean</groupId>
       <artifactId>ebean</artifactId>
       <version>${ebean.version}</version>
       <scope>provided</scope>

--- a/test/src/test/java/test/enhancement/CreateNullListTest.java
+++ b/test/src/test/java/test/enhancement/CreateNullListTest.java
@@ -23,17 +23,20 @@ public class CreateNullListTest extends BaseTest {
 
     assertTrue(intercept.isNew());
 
-    Set<String> codes = customer.getCodes();
-    assertNotNull(codes);
-    assertThat(codes).isInstanceOf(LinkedHashSet.class);
+    assertNotNull(customer.nonNullArrayOne());
+    assertNotNull(customer.nonNullArrayTwo());
+    assertNotNull(customer.nonNullArrayThree());
+    assertThat(customer.nonNullArrayOne()).isInstanceOf(ArrayList.class);
+    assertThat(customer.nonNullArrayTwo()).isInstanceOf(LinkedHashSet.class);
+    assertThat(customer.nonNullArrayThree()).isInstanceOf(ArrayList.class);
 
-    List<String> codesList = customer.getCodesList();
-    assertNotNull(codesList);
-    assertThat(codesList).isInstanceOf(ArrayList.class);
+    assertNull(customer.getCodes());
+
+    assertNull(customer.getCodesList());
 
     Set<String> codes2 = customer.getCodes2();
-    assertNotNull(codes);
-    assertThat(codes2).isInstanceOf(LinkedHashSet.class);
+    assertNotNull(codes2);
+    assertThat(codes2).isInstanceOf(HashSet.class);
 
     List<String> codesList2 = customer.getCodesList2();
     assertNotNull(codesList2);
@@ -46,15 +49,12 @@ public class CreateNullListTest extends BaseTest {
     // contacts created automatically when "checkNullManyFields" is set
     List<Contact> contacts = customer.getContacts();
     assertNotNull(contacts);
-
     // Not invoking lazy loading btw
     assertTrue(contacts.isEmpty());
 
     contacts.add(new Contact("1"));
-    assertFalse(contacts.isEmpty());
-
+    assertThat(contacts).isNotEmpty();
     assertTrue(contacts instanceof BeanList<?>);
-
   }
 
 }

--- a/test/src/test/java/test/enhancement/CustomerEntityTest.java
+++ b/test/src/test/java/test/enhancement/CustomerEntityTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class CustomerEntityTest extends BaseTest {
 
-  private static final int PROPERTY_COUNT = 12;
+  private static final int PROPERTY_COUNT = 15;
 
   @Test
   public void testBasic() {
@@ -55,6 +55,9 @@ public class CustomerEntityTest extends BaseTest {
     assertEquals("codesList2", custFieldNames[9]);
     assertEquals("codesList3", custFieldNames[10]);
     assertEquals("codesTree", custFieldNames[11]);
+    assertEquals("nonNullArrayOne", custFieldNames[12]);
+    assertEquals("nonNullArrayTwo", custFieldNames[13]);
+    assertEquals("nonNullArrayThree", custFieldNames[14]);
 
     assertEquals("id", custEb._ebean_getPropertyName(0));
     assertEquals("version", custEb._ebean_getPropertyName(1));
@@ -68,6 +71,9 @@ public class CustomerEntityTest extends BaseTest {
     assertEquals("codesList2", custEb._ebean_getPropertyName(9));
     assertEquals("codesList3", custEb._ebean_getPropertyName(10));
     assertEquals("codesTree", custEb._ebean_getPropertyName(11));
+    assertEquals("nonNullArrayOne", custEb._ebean_getPropertyName(12));
+    assertEquals("nonNullArrayTwo", custEb._ebean_getPropertyName(13));
+    assertEquals("nonNullArrayThree", custEb._ebean_getPropertyName(14));
 
     EntityBeanIntercept customerIntercept = custEb._ebean_getIntercept();
 

--- a/test/src/test/java/test/model/Customer.java
+++ b/test/src/test/java/test/model/Customer.java
@@ -2,7 +2,9 @@ package test.model;
 
 
 import io.ebean.annotation.DbArray;
+import io.ebean.annotation.NotNull;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.OneToMany;
 import java.util.*;
@@ -26,7 +28,7 @@ public class Customer extends BaseEntity {
   @DbArray
   Set<String> codes2 = new HashSet<>();
 
-  @DbArray
+  @DbArray(nullable = false)
   List<String> codesList2 = new ArrayList<>();
 
   @DbArray
@@ -34,6 +36,17 @@ public class Customer extends BaseEntity {
 
   @DbArray
   Set<String> codesTree = new TreeSet<>();
+
+  @DbArray(nullable = false)
+  List<String> nonNullArrayOne;
+
+  @NotNull
+  @DbArray
+  Set<String> nonNullArrayTwo;
+
+  @Column(nullable = false)
+  @DbArray
+  List<String> nonNullArrayThree;
 
   public Customer() {
     codesList3.add("foo");
@@ -90,5 +103,17 @@ public class Customer extends BaseEntity {
 
   public Set<String> getCodesTree() {
     return codesTree;
+  }
+
+  public List<String> nonNullArrayOne() {
+    return nonNullArrayOne;
+  }
+
+  public Set<String> nonNullArrayTwo() {
+    return nonNullArrayTwo;
+  }
+
+  public List<String> nonNullArrayThree() {
+    return nonNullArrayThree;
   }
 }

--- a/test/src/test/resources/ebean.mf
+++ b/test/src/test/resources/ebean.mf
@@ -6,4 +6,5 @@ debug: 3
 synthetic: false
 transient-init: true
 transient-init-error: false
+allow-nullable-dbarray: true
 


### PR DESCRIPTION
Instead, when this is turned on (initially we must explicitly turn this on via ebean.mf) then ONLY DbArray that are nullable = false via @NotNull, @DbArray(nullable=false), @Column(nullable=false) ... are automatically initialised (and hence never null).

We will look to by default turn this on very shortly but release initially requiring it to be explicitly enabled and preserve the current behaviour.