### PR TITLE
Allow other types of TQAssocBean

### DIFF
--- a/ebean-agent/src/main/java/io/ebean/enhance/querybean/ClassInfo.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/querybean/ClassInfo.java
@@ -181,7 +181,7 @@ class ClassInfo implements Constants {
   /**
    * Add fields and constructors to assoc type query beans as necessary.
    */
-  void addAssocBeanExtras(ClassVisitor cv) {
+  void addAssocBeanExtras(ClassVisitor cv, String superName) {
     if (isLog(4)) {
       String msg = "... add fields";
       if (!hasBasicConstructor) {
@@ -195,11 +195,11 @@ class ClassInfo implements Constants {
 
     if (!hasBasicConstructor) {
       // add the assoc bean basic constructor
-      new TypeQueryAssocBasicConstructor(this, cv, ASSOC_BEAN_BASIC_CONSTRUCTOR_DESC, ASSOC_BEAN_BASIC_SIG).visitCode();
+      new TypeQueryAssocBasicConstructor(superName, this, cv, ASSOC_BEAN_BASIC_CONSTRUCTOR_DESC, ASSOC_BEAN_BASIC_SIG).visitCode();
     }
     if (!hasMainConstructor) {
       // add the assoc bean main constructor
-      new TypeQueryAssocMainConstructor(this, cv, ASSOC_BEAN_MAIN_CONSTRUCTOR_DESC, ASSOC_BEAN_MAIN_SIG).visitCode();
+      new TypeQueryAssocMainConstructor(superName, this, cv, ASSOC_BEAN_MAIN_CONSTRUCTOR_DESC, ASSOC_BEAN_MAIN_SIG).visitCode();
     }
 
   }

--- a/ebean-agent/src/main/java/io/ebean/enhance/querybean/Constants.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/querybean/Constants.java
@@ -17,8 +17,6 @@ interface Constants {
    */
   String ANNOTATION_TYPE_QUERY_BEAN = EnhanceConstants.TYPEQUERYBEAN_ANNOTATION;
 
-  String TQ_ASSOC_BEAN = "io/ebean/typequery/TQAssocBean";
-
   /**
    * The TQRootBean object class name.
    */

--- a/ebean-agent/src/main/java/io/ebean/enhance/querybean/TypeQueryAssocBasicConstructor.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/querybean/TypeQueryAssocBasicConstructor.java
@@ -16,14 +16,16 @@ public class TypeQueryAssocBasicConstructor extends BaseConstructorAdapter imple
 
   private final ClassInfo classInfo;
   private final ClassVisitor cv;
+  private final String superName;
   private final String desc;
   private final String signature;
 
   /**
    * Construct for a query bean class given its associated entity bean domain class and a class visitor.
    */
-  public TypeQueryAssocBasicConstructor(ClassInfo classInfo, ClassVisitor cv, String desc, String signature) {
+  public TypeQueryAssocBasicConstructor(String superName, ClassInfo classInfo, ClassVisitor cv, String desc, String signature) {
     super();
+    this.superName = superName;
     this.cv = cv;
     this.classInfo = classInfo;
     this.desc = desc;
@@ -41,7 +43,7 @@ public class TypeQueryAssocBasicConstructor extends BaseConstructorAdapter imple
     mv.visitVarInsn(ALOAD, 1);
     mv.visitVarInsn(ALOAD, 2);
     mv.visitInsn(ACONST_NULL);
-    mv.visitMethodInsn(INVOKESPECIAL, TQ_ASSOC_BEAN, INIT, "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;)V", false);
+    mv.visitMethodInsn(INVOKESPECIAL, superName, INIT, "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;)V", false);
     Label l1 = new Label();
     mv.visitLabel(l1);
     mv.visitLineNumber(2, l1);

--- a/ebean-agent/src/main/java/io/ebean/enhance/querybean/TypeQueryAssocMainConstructor.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/querybean/TypeQueryAssocMainConstructor.java
@@ -16,14 +16,16 @@ public class TypeQueryAssocMainConstructor extends BaseConstructorAdapter implem
 
   private final ClassInfo classInfo;
   private final ClassVisitor cv;
+  private final String superName;
   private final String desc;
   private final String signature;
 
   /**
    * Construct for a query bean class given its associated entity bean domain class and a class visitor.
    */
-  public TypeQueryAssocMainConstructor(ClassInfo classInfo, ClassVisitor cv, String desc, String signature) {
+  public TypeQueryAssocMainConstructor(String superName, ClassInfo classInfo, ClassVisitor cv, String desc, String signature) {
     super();
+    this.superName = superName;
     this.cv = cv;
     this.classInfo = classInfo;
     this.desc = desc;
@@ -41,7 +43,7 @@ public class TypeQueryAssocMainConstructor extends BaseConstructorAdapter implem
     mv.visitVarInsn(ALOAD, 1);
     mv.visitVarInsn(ALOAD, 2);
     mv.visitVarInsn(ALOAD, 3);
-    mv.visitMethodInsn(INVOKESPECIAL, TQ_ASSOC_BEAN, INIT, "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;)V", false);
+    mv.visitMethodInsn(INVOKESPECIAL, superName, INIT, "(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/String;)V", false);
     Label l1 = new Label();
     mv.visitLabel(l1);
     mv.visitLineNumber(2, l1);

--- a/ebean-agent/src/main/java/io/ebean/enhance/querybean/TypeQueryClassAdapter.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/querybean/TypeQueryClassAdapter.java
@@ -21,6 +21,7 @@ public class TypeQueryClassAdapter extends ClassVisitor implements Constants {
   private final ClassLoader loader;
   private boolean typeQueryRootBean;
   private String className;
+  private String superName;
   private String signature;
   private ClassInfo classInfo;
   private final AnnotationInfo annotationInfo = new AnnotationInfo(null);
@@ -35,6 +36,7 @@ public class TypeQueryClassAdapter extends ClassVisitor implements Constants {
   public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
     super.visit(version, access, name, signature, superName, interfaces);
     this.typeQueryRootBean = TQ_ROOT_BEAN.equals(superName);
+    this.superName = superName;
     this.className = name;
     this.signature = signature;
     this.classInfo = new ClassInfo(enhanceContext, name);
@@ -142,11 +144,11 @@ public class TypeQueryClassAdapter extends ClassVisitor implements Constants {
   private MethodVisitor handleAssocBeanConstructor(int access, String name, String desc, String signature, String[] exceptions) {
     if (desc.equals(ASSOC_BEAN_BASIC_CONSTRUCTOR_DESC)) {
       classInfo.setHasBasicConstructor();
-      return new TypeQueryAssocBasicConstructor(classInfo, cv, desc, signature);
+      return new TypeQueryAssocBasicConstructor(superName, classInfo, cv, desc, signature);
     }
     if (desc.equals(ASSOC_BEAN_MAIN_CONSTRUCTOR_DESC)) {
       classInfo.setHasMainConstructor();
-      return new TypeQueryAssocMainConstructor(classInfo, cv, desc, signature);
+      return new TypeQueryAssocMainConstructor(superName, classInfo, cv, desc, signature);
     }
     // leave as is
     return super.visitMethod(access, name, desc, signature, exceptions);
@@ -159,7 +161,7 @@ public class TypeQueryClassAdapter extends ClassVisitor implements Constants {
     }
     if (classInfo.isTypeQueryBean()) {
       if (!typeQueryRootBean) {
-        classInfo.addAssocBeanExtras(cv);
+        classInfo.addAssocBeanExtras(cv, superName);
       } else {
         enhanceContext.summaryQueryBean(className);
       }


### PR DESCRIPTION
Rather than always assume io/ebean/typequery/TQAssocBean is the parent type of "associated" query beans as we are going to improve here.