### PR TITLE
For Type query beans Alias, do not use setRoot()

### DIFF
--- a/ebean-agent/src/main/java/io/ebean/enhance/querybean/TypeQueryConstructorAdapter.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/querybean/TypeQueryConstructorAdapter.java
@@ -20,6 +20,7 @@ class TypeQueryConstructorAdapter extends BaseConstructorAdapter implements Opco
   private final String signature;
 
   /**
+   * OLD Type Query beans ONLY, prior to {@code @TypeQueryBean("v1")}.
    * Construct for a query bean class given its associated entity bean domain class and a class visitor.
    */
   TypeQueryConstructorAdapter(ClassInfo classInfo, String domainClass, ClassVisitor cv, String desc, String signature) {

--- a/ebean-agent/src/main/java/io/ebean/enhance/querybean/TypeQueryConstructorForAlias.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/querybean/TypeQueryConstructorForAlias.java
@@ -38,13 +38,6 @@ class TypeQueryConstructorForAlias extends BaseConstructorAdapter implements Opc
     mv.visitVarInsn(ALOAD, 0);
     mv.visitVarInsn(ILOAD, 1);
     mv.visitMethodInsn(INVOKESPECIAL, TQ_ROOT_BEAN, INIT, "(Z)V", false);
-    Label l1 = new Label();
-    mv.visitLabel(l1);
-    mv.visitLineNumber(2, l1);
-    mv.visitVarInsn(ALOAD, 0);
-    mv.visitVarInsn(ALOAD, 0);
-    mv.visitMethodInsn(INVOKEVIRTUAL, classInfo.getClassName(), "setRoot", "(Ljava/lang/Object;)V", false);
-
 
     // init all the properties
     List<FieldInfo> fields = classInfo.getFields();


### PR DESCRIPTION
We are removing the setRoot() method going forward. The TypeQueryConstructorAdapter still calls it but it is only used for older query beans.