### PR TITLE
#214 Add back maven files into /META-INF/maven/io.ebean/ebean-agent

### DIFF
--- a/ebean-agent/pom.xml
+++ b/ebean-agent/pom.xml
@@ -122,6 +122,7 @@
         <version>3.2.0</version>
         <configuration>
           <archive>
+            <addMavenDescriptor>true</addMavenDescriptor>
             <manifestEntries>
               <build-version>${project.version}</build-version>
             </manifestEntries>


### PR DESCRIPTION
This includes the pom.properties and pom.xml (4kb)

An alternative would be to search all /META-INF/manifest.mf files as suggested. This seems an easier option but adds the 4kb to the ebean-agent.jar.