### PR TITLE
For #220, detect unexpected OneToMany initialisation cases

### DIFF
--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/ConstructorDeferredCode.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/ConstructorDeferredCode.java
@@ -189,7 +189,7 @@ final class ConstructorDeferredCode implements Opcodes {
    */
   boolean consumeVisitFieldInsn(int opcode, String owner, String name, String desc) {
     if (opcode == PUTFIELD) {
-      if (state == State.MAYBE_UNSUPPORTED && meta.isConsumeInitMany(name)) {
+      if (meta.isConsumeInitMany(name) && unsupportedInitialisation()) {
         // a OneToMany/ManyToMany is initialised in an unsupported manor
         meta.addUnsupportedInitMany(name);
         flush();
@@ -219,6 +219,15 @@ final class ConstructorDeferredCode implements Opcodes {
     }
     flush();
     return false;
+  }
+
+  /**
+   * Return true when a OneToMany or ManyToMany is not initialised in a supported manor.
+   */
+  private boolean unsupportedInitialisation() {
+    return state == State.MAYBE_UNSUPPORTED
+      || state == State.UNSET // proceeded by GETSTATIC field bytecode like Collections.EMPTY_LIST
+      || state == State.INVOKE_SPECIAL && !isConsumeManyType(); // e.g. new BeanList()
   }
 
   boolean consumeVisitLabel(Label label) {

--- a/test/src/test/java/test/model/WithInitialisedCollections2.java
+++ b/test/src/test/java/test/model/WithInitialisedCollections2.java
@@ -26,6 +26,11 @@ public class WithInitialisedCollections2 extends BaseEntity {
   @OneToMany(cascade = CascadeType.PERSIST)
   Map<Long,Contact> mapCollEmpty = Collections.emptyMap();
 
+  // @OneToMany final List<Contact> listCollNotValidInitialisation0 = new io.ebean.common.BeanList<>();
+  // @OneToMany final List<Contact> listCollNotValidInitialisation1 = Collections.EMPTY_LIST;
+  // @OneToMany final List<Contact> listCollNotValidInitialisation2 = List.of(new Contact("junk"));
+  // @OneToMany final List<Contact> listCollNotValidInitialisation3 = Collections.unmodifiableList(Collections.emptyList());
+
   @Transient
   List<String> transientList = List.of();
   @Transient


### PR DESCRIPTION
Previously didn't account for Collections.EMPTY_LIST (which is field bytecode rather than method bytecode). Also account for initialising as an unsupported List, Set, Map implementation like ebeans own BeanList. The expected implementations are ArrayList, LinkedHashSet, LinkedHashMap.