### PR TITLE
For #220, explicitly allow OneToMany to be set via constructor

### DIFF
--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/ConstructorDeferredCode.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/ConstructorDeferredCode.java
@@ -79,6 +79,10 @@ final class ConstructorDeferredCode implements Opcodes {
       state = State.ALOAD;
       return true;
     }
+    if (opcode == ALOAD) {
+      // maybe constructor initialisation of OneToMany
+      state = State.ALOAD;
+    }
     return false;
   }
 
@@ -225,6 +229,10 @@ final class ConstructorDeferredCode implements Opcodes {
    * Return true when a OneToMany or ManyToMany is not initialised in a supported manor.
    */
   private boolean unsupportedInitialisation() {
+    if (state == State.ALOAD) {
+      // allow constructor initialisation of a OneToMany
+      return false;
+    }
     return state == State.MAYBE_UNSUPPORTED
       || state == State.UNSET // proceeded by GETSTATIC field bytecode like Collections.EMPTY_LIST
       || state == State.INVOKE_SPECIAL && !isConsumeManyType(); // e.g. new BeanList()

--- a/test/src/test/java/test/model/ReferencingBean.java
+++ b/test/src/test/java/test/model/ReferencingBean.java
@@ -1,0 +1,28 @@
+package test.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+public class ReferencingBean {
+
+  @Id @GeneratedValue
+  UUID id;
+
+  @OneToMany
+  private List<PBean> rootBeans;
+
+  public ReferencingBean(List<PBean> rootBeans) {
+    this.rootBeans = rootBeans;
+  }
+
+  public List<PBean> getRootBeans() {
+    return rootBeans;
+  }
+
+}


### PR DESCRIPTION
With 220 the ebean-agent is now conservative and only allows certain initialisation for OneToMany. This fixes the 220 change to allow OneToMany to be set via constructor. [PUTFIELD on a OneToMany was proceeded by an ALOAD]