### PR TITLE
Support Lombok SuperBuilder for - Unsupported initialisation of @OneT…

### DIFF
--- a/ebean-agent/src/main/java/io/ebean/enhance/entity/ConstructorDeferredCode.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/entity/ConstructorDeferredCode.java
@@ -46,6 +46,7 @@ final class ConstructorDeferredCode implements Opcodes {
     KT_CHECKCAST,   // optional kotlin state
     KT_LABEL,        // optional kotlin state
     EMPTY,
+    GETFIELD,
     MAYBE_UNSUPPORTED
   }
 
@@ -222,6 +223,9 @@ final class ConstructorDeferredCode implements Opcodes {
       }
     }
     flush();
+    if (opcode == GETFIELD) {
+      state = State.GETFIELD;
+    }
     return false;
   }
 
@@ -229,8 +233,8 @@ final class ConstructorDeferredCode implements Opcodes {
    * Return true when a OneToMany or ManyToMany is not initialised in a supported manor.
    */
   private boolean unsupportedInitialisation() {
-    if (state == State.ALOAD) {
-      // allow constructor initialisation of a OneToMany
+    if (state == State.ALOAD || state == State.GETFIELD) {
+      // allow constructor initialisation of a OneToMany via constructor arg or builder
       return false;
     }
     return state == State.MAYBE_UNSUPPORTED

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -94,6 +94,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.38</version>
+    </dependency>
   </dependencies>
 
   <build>
@@ -104,6 +109,11 @@
         <version>3.11.0</version>
         <configuration>
           <annotationProcessorPaths>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.38</version>
+            </path>
             <path>
               <groupId>io.ebean</groupId>
               <artifactId>querybean-generator</artifactId>

--- a/test/src/test/java/test/model/lombok/App.java
+++ b/test/src/test/java/test/model/lombok/App.java
@@ -1,0 +1,15 @@
+package test.model.lombok;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class App {
+
+  @Id
+  long id;
+
+  @Column
+  String name;
+}

--- a/test/src/test/java/test/model/lombok/Msock.java
+++ b/test/src/test/java/test/model/lombok/Msock.java
@@ -1,0 +1,133 @@
+package test.model.lombok;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import lombok.Generated;
+
+import java.util.List;
+
+@Entity
+@Table(name = "stock")
+public class Msock {
+
+  private String name;
+  private String code;
+  @ManyToMany(fetch = FetchType.LAZY)
+  private List<App> myapps;
+
+  @Generated
+  public Msock() {
+  }
+
+  @Generated
+  protected Msock(Msock.StockBuilder<?, ?> b) {
+    this.name = b.name;
+    this.code = b.code;
+    this.myapps = b.apps;
+  }
+
+  @Generated
+  public Msock(String name, String code, List<App> apps) {
+    this.name = name;
+    this.code = code;
+    this.myapps = apps;
+  }
+
+  @Generated
+  public static Msock.StockBuilder<?, ?> builder() {
+    return new Msock.StockBuilderImpl();
+  }
+
+  @Generated
+  public String getName() {
+    return this.name;
+  }
+
+  @Generated
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  @Generated
+  public String getCode() {
+    return this.code;
+  }
+
+  @Generated
+  public void setCode(String code) {
+    this.code = code;
+  }
+
+  @Generated
+  public List<App> getApps() {
+    return this.myapps;
+  }
+
+  @Generated
+  public void setApps(List<App> myapps) {
+    this.myapps = myapps;
+  }
+
+  @Generated
+  public abstract static class StockBuilder<C extends Msock, B extends Msock.StockBuilder<C, B>> {
+    @Generated
+    private String name;
+    @Generated
+    private String code;
+    @Generated
+    private List<App> apps;
+
+    public StockBuilder() {
+    }
+
+    @Generated
+    public B name(String name) {
+      this.name = name;
+      return this.self();
+    }
+
+    @Generated
+    public B code(String code) {
+      this.code = code;
+      return this.self();
+    }
+
+    @Generated
+    public B apps(List<App> apps) {
+      this.apps = apps;
+      return this.self();
+    }
+
+    @Generated
+    protected abstract B self();
+
+    @Generated
+    public abstract C build();
+
+    @Generated
+    public String toString() {
+      String var10000 = this.name;
+      return "Stock.StockBuilder(name=" + var10000 + ", code=" + this.code + ", apps=" + String.valueOf(this.apps) + ")";
+    }
+  }
+
+  @Generated
+  private static final class StockBuilderImpl extends Msock.StockBuilder<Msock, Msock.StockBuilderImpl> {
+    @Generated
+    private StockBuilderImpl() {
+    }
+
+    @Generated
+    protected StockBuilderImpl self() {
+      return this;
+    }
+
+    @Generated
+    public Msock build() {
+      return new Msock(this);
+    }
+  }
+}
+


### PR DESCRIPTION
…oMany or @ManyToMany ...

ERROR: Unsupported initialisation of @OneToMany or @ManyToMany on: test/entity/User fields: [roles] Refer: https://ebean.io/docs/trouble-shooting#initialisation-error]

The SuperBuilder creates a constructor that takes a builder rather than the fields, and assigned the OneToMany/ManyToMany/DbArray via the builder with a GETFIELD followed by PUTFIELD