### PR TITLE
Only log "defaulted common supertype" message at debug level 2+

### DIFF
--- a/ebean-agent/src/main/java/io/ebean/enhance/Transformer.java
+++ b/ebean-agent/src/main/java/io/ebean/enhance/Transformer.java
@@ -244,7 +244,7 @@ public class Transformer implements ClassFileTransformer {
   private void logUnresolvedCommonSuper(String className) {
     if (!keepUnresolved && !unresolved.isEmpty()) {
       for (CommonSuperUnresolved commonUnresolved : unresolved) {
-        log(0, className, commonUnresolved.getMessage());
+        log(2, className, commonUnresolved.getMessage());
       }
       unresolved.clear();
     }


### PR DESCRIPTION
We are at a point where this message produces noise and is not an indication of an issue so lets log it at level 2+